### PR TITLE
Migrate `libwheel_angle` project

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -1,0 +1,53 @@
+name: Continuous Integration
+
+on: [pull_request]
+
+jobs:
+  Static-Analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Conan
+        run: |
+          python3 -m pip install conan
+          conan profile detect --force
+
+      - uses: actions/checkout@v3
+
+      - name: Configure Conan
+        run: |
+          conan install . --output-folder=build --build=missing
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release .
+
+      - name: Run clang-tidy
+        run: |
+          clang-tidy -p build/ test/*.cpp libwheel/angle/*.hpp
+
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Conan
+        run: |
+          python3 -m pip install conan
+          conan profile detect --force
+
+      - uses: actions/checkout@v3
+
+      - name: Configure Conan
+        run: |
+          conan install . --output-folder=build --build=missing
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release .
+
+      - name: Build
+        run: |
+          cmake --build build
+
+      - name: Test
+        run: |
+          cd build
+          ctest

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+gtest/1.13.0
+
+[generators]
+CMakeDeps
+CMakeToolchain

--- a/libwheel/angle/CMakeLists.txt
+++ b/libwheel/angle/CMakeLists.txt
@@ -1,0 +1,52 @@
+add_library(wheel_angleLibrary INTERFACE)
+add_library(libwheel::angle ALIAS wheel_angleLibrary)
+
+target_include_directories(wheel_angleLibrary
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_compile_features(wheel_angleLibrary
+  INTERFACE
+    cxx_std_20
+)
+
+target_compile_options(wheel_angleLibrary
+  INTERFACE
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Wpedantic
+    -Wold-style-cast
+    -Wunused
+    -Wconversion
+    -Wsign-conversion
+    -Wcast-align
+    -Woverloaded-virtual
+    -Wdouble-promotion
+    -Wformat=2
+    -Wimplicit-fallthrough
+    -Werror
+)
+
+set_target_properties(wheel_angleLibrary PROPERTIES
+  EXPORT_NAME angle
+)
+
+install(TARGETS wheel_angleLibrary
+  EXPORT wheel_angleTargets
+  INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/angle
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(EXPORT wheel_angleTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_angle
+  FILE libwheel_angleTargets.cmake
+  NAMESPACE libwheel::
+)

--- a/libwheel/angle/README.md
+++ b/libwheel/angle/README.md
@@ -1,0 +1,45 @@
+# Wheel Angle Library
+
+## Introduction
+
+This library module contains an angle class.
+
+### What is the Wheel Library?
+
+A play on the phrase, "Don't reinvent the wheel," the Wheel Library (`libwheel`) contains my implementations for
+various algorithms and data structures. It also comprises several library re-implementations using modern techniques
+and designs that I consider to be improvements on the originals. Occasionally, I may add some completely novel modules.
+The Wheel Library's structure follows the Boost Library's, splitting components into separate modules and source code
+repositories.
+
+## Getting started
+
+### Building from source
+
+1. Install Conan dependencies
+
+    ```shell
+    $ conan install . --output-folder=build --build=missing
+    ```
+
+2. Configure the CMake project
+
+    ```shell
+    $ cmake -B build -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release .
+    ```
+
+3. Build the library
+
+    ```shell
+    $ cmake --build build
+    ```
+
+4. (Optional) Install the library
+
+    ```shell
+    $ sudo cmake --install build  # Install to /usr/local/
+    ```
+    or
+    ```shell
+    $ cmake --install build --prefix=<install_path>  # Install to custom location
+    ```

--- a/libwheel/angle/angle.hpp
+++ b/libwheel/angle/angle.hpp
@@ -1,0 +1,70 @@
+#ifndef LIBWHEEL_ANGLE_ANGLE_HPP
+#define LIBWHEEL_ANGLE_ANGLE_HPP
+
+#include <complex>
+#include <concepts>
+
+namespace wheel {
+
+template <std::floating_point StorageType>
+class AngleDisplacement;
+
+template <std::floating_point StorageType>
+class Angle {
+  public:
+    explicit Angle(StorageType value) noexcept : value_{std::polar(static_cast<StorageType>(1.0), value)} {}
+
+    [[nodiscard]] auto getValue() const noexcept -> StorageType {
+        auto value{std::arg(value_)};
+
+        if (value < static_cast<StorageType>(0.0)) {
+            value += 2 * static_cast<StorageType>(std::numbers::pi);
+        }
+
+        return value;
+    }
+
+    auto setValue(StorageType value) noexcept { value_ = std::polar(static_cast<StorageType>(1.0), value); }
+
+  private:
+    friend AngleDisplacement<StorageType>;
+
+    std::complex<StorageType> value_;
+};
+
+template <std::floating_point StorageType>
+class AngleDisplacement {
+  public:
+    explicit AngleDisplacement(const Angle<StorageType> &lhs, const Angle<StorageType> &rhs) noexcept
+        : value_{std::arg(rhs.value_ / lhs.value_)} {}
+
+    [[nodiscard]] auto getValue() const noexcept -> StorageType { return value_; }
+
+  private:
+    StorageType value_;
+};
+
+template <std::floating_point StorageType>
+[[nodiscard]] inline auto displacement(const Angle<StorageType> &lhs, const Angle<StorageType> &rhs) {
+    return AngleDisplacement<StorageType>{lhs, rhs};
+}
+
+template <std::floating_point StorageType>
+class AngleDistance {
+  public:
+    explicit AngleDistance(StorageType value) noexcept : value_{value} {}
+
+    [[nodiscard]] auto getValue() const noexcept -> StorageType { return value_; }
+
+  private:
+    StorageType value_;
+};
+
+template <std::floating_point StorageType>
+[[nodiscard]] inline auto distance(const Angle<StorageType> &lhs, const Angle<StorageType> &rhs) {
+    return AngleDistance<StorageType>{std::abs(displacement(lhs, rhs).getValue())};
+}
+
+} // namespace wheel
+
+#endif // LIBWHEEL_ANGLE_ANGLE_HPP

--- a/test/angle/CMakeLists.txt
+++ b/test/angle/CMakeLists.txt
@@ -1,0 +1,12 @@
+include(GoogleTest)
+
+add_executable(test_angle test_angle.cpp)
+
+target_link_libraries(test_angle
+  PRIVATE
+    libwheel::angle
+    GTest::gtest
+    GTest::gtest_main
+)
+
+gtest_discover_tests(test_angle)

--- a/test/angle/test_angle.cpp
+++ b/test/angle/test_angle.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <libwheel/angle/angle.hpp>
+
+TEST(AngleTest, ConstructorWithinTwoPi) {
+    const wheel::Angle<double> angle{5 * std::numbers::pi / 4.0};
+
+    EXPECT_DOUBLE_EQ(angle.getValue(), 5 * std::numbers::pi / 4.0);
+}
+
+TEST(AngleTest, ConstructorBeyondTwoPi) {
+    const wheel::Angle<double> angle{3 * std::numbers::pi};
+
+    EXPECT_DOUBLE_EQ(angle.getValue(), std::numbers::pi);
+}
+
+TEST(AngleTest, ConstructorNegativeWithinTwoPi) {
+    const wheel::Angle<double> angle{-5 * std::numbers::pi / 4.0};
+
+    EXPECT_DOUBLE_EQ(angle.getValue(), 3 * std::numbers::pi / 4.0);
+}
+
+TEST(AngleTest, ConstructorNegativeBeyondTwoPi) {
+    const wheel::Angle<double> angle{-6 * std::numbers::pi};
+
+    // Rounding errors prevent the two values from being within 4 ULP of each other
+    EXPECT_NEAR(angle.getValue(), 0.0, 1e-15);
+}
+
+TEST(AngleTest, Displacement) {
+    using Angle = wheel::Angle<double>;
+
+    const Angle angle_1{std::numbers::pi / 2.0};
+    const Angle angle_2{std::numbers::pi};
+
+    EXPECT_DOUBLE_EQ(wheel::displacement(angle_1, angle_2).getValue(), std::numbers::pi / 2.0);
+    EXPECT_DOUBLE_EQ(wheel::displacement(angle_2, angle_1).getValue(), -std::numbers::pi / 2.0);
+}
+
+TEST(AngleTest, DisplacementOneEighty) {
+    using Angle = wheel::Angle<double>;
+
+    const Angle angle_1{0.0};
+    const Angle angle_2{std::numbers::pi};
+
+    EXPECT_DOUBLE_EQ(wheel::displacement(angle_1, angle_2).getValue(), std::numbers::pi);
+    EXPECT_DOUBLE_EQ(wheel::displacement(angle_2, angle_1).getValue(), -std::numbers::pi);
+}
+
+TEST(AngleTest, DisplacementSameAngle) {
+    const wheel::Angle<double> angle{3 * std::numbers::pi / 4.0};
+
+    EXPECT_DOUBLE_EQ(wheel::displacement(angle, angle).getValue(), 0.0);
+}
+
+TEST(AngleTest, Distance) {
+    using Angle = wheel::Angle<double>;
+
+    const Angle angle_1{2.0 * std::numbers::pi / 180.0};
+    const Angle angle_2{359.0 * std::numbers::pi / 180.0};
+
+    // Rounding errors prevent the two values from being within 4 ULP of each other
+    EXPECT_NEAR(wheel::distance(angle_1, angle_2).getValue(), 3.0 * std::numbers::pi / 180.0, 1e-15);
+}


### PR DESCRIPTION
This PR migrates the existing code from the `libwheel_angle` sub-project. There are still some integration cleanup that needs to be done, but that should take place after the other sub-projects get merged.

Closes #9 