### PR TITLE
Migrate `libwheel_metaprogramming` project

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -1,6 +1,10 @@
 name: Continuous Integration
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   Static-Analysis:
@@ -23,7 +27,7 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          clang-tidy -p build/ test/*.cpp libwheel/angle/*.hpp
+          clang-tidy -p build/ test/*.cpp libwheel/angle/*.hpp libwheel/metaprogramming/*.hpp
 
   Unit-Tests:
     runs-on: ubuntu-latest

--- a/libwheel/metaprogramming/CMakeLists.txt
+++ b/libwheel/metaprogramming/CMakeLists.txt
@@ -1,0 +1,35 @@
+include(GNUInstallDirs)
+
+add_library(wheel_metaprogrammingLibrary INTERFACE)
+add_library(libwheel::metaprogramming ALIAS wheel_metaprogrammingLibrary)
+
+target_include_directories(wheel_metaprogrammingLibrary
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_compile_features(wheel_metaprogrammingLibrary
+  INTERFACE
+    cxx_std_20
+)
+
+set_target_properties(wheel_metaprogrammingLibrary PROPERTIES
+  EXPORT_NAME metaprogramming
+)
+
+install(TARGETS wheel_metaprogrammingLibrary
+  EXPORT wheel_metaprogrammingTargets
+  INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/metaprogramming
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(EXPORT wheel_metaprogrammingTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_metaprogramming
+  FILE libwheel_metaprogrammingConfig.cmake
+  NAMESPACE libwheel::
+)

--- a/libwheel/metaprogramming/README.md
+++ b/libwheel/metaprogramming/README.md
@@ -1,0 +1,67 @@
+# Introduction
+
+The Wheel Metaprogramming library (`libwheel_metaprogramming`) contains various metaprogramming facilities, such as
+meta-functions, concepts, and type traits.
+
+# What is the Wheel project?
+
+A play on the phrase, "Don't reinvent the wheel," the Wheel project (`libwheel`) implements various algorithms and data
+structures. Some contributions follow existing libraries but with modern designs and techniques. Others are novel and
+built from scratch. The Wheel project's structure roughly resembles the Boost Library's, separating software
+collections into different libraries. One notable difference is that Wheel libraries version themselves independently
+compared to Boost's project-wide versioning.
+
+# Building the library
+
+This library is header only, so you can embed it directly into your project. You can also build it using CMake and
+import it using CMake's `find_package(...)` functionality.
+
+## Project CMake options
+
+| Option                                          | Default Value                                  | Description                                                                                                                            |
+| ----------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `wheel_metaprogramming_ENABLE_TESTING`          | `TRUE` if top-level project; `FALSE` otherwise | Enable unit tests. Unit tests in this project are compile-time `static_assert`s, so the test code will only compile if the tests pass. |
+| `wheel_metaprogramming_EXPORT_COMPILE_COMMANDS` | `ON`                                           | Export CMake compile commands. This helps VS Code provide accurate IntelliSense features while editing (_e.g._, code completion).      |
+
+## Build steps (with default options)
+
+1. Configure the CMake project
+
+   ```shell
+   $ cmake -B build .
+   ```
+
+2. Build the library
+
+   ```shell
+   $ cmake --build build
+   ```
+
+3. (Optional) Install the library
+
+   ```shell
+   $ sudo cmake --install build  # Install to /usr/local/
+   ```
+
+   or
+
+   ```shell
+   $ cmake --install build --prefix=<install_path>  # Install to custom location
+   ```
+
+# Using Wheel Metaprogramming in your project
+
+1. Add Wheel Metaprogramming as a dependency in your project
+
+   ```cmake
+   find_package(libwheel_metaprogramming REQUIRED)
+   ```
+
+2. Link against it in your project
+
+   ```cmake
+   target_link_libraries(your_project
+     PRIVATE
+       libwheel::metaprogramming
+   )
+   ```

--- a/libwheel/metaprogramming/has_type_member.hpp
+++ b/libwheel/metaprogramming/has_type_member.hpp
@@ -1,0 +1,18 @@
+#ifndef LIBWHEEL_METAPROGRAMMING_HAS_TYPE_MEMBER_HPP
+#define LIBWHEEL_METAPROGRAMMING_HAS_TYPE_MEMBER_HPP
+
+namespace wheel {
+
+/**
+ * @brief Check if specified type has a type member variable
+ *
+ * Concept is satisfied only if specified type has a type member variable.
+ *
+ * @tparam T Type being checked
+ */
+template <typename T>
+concept has_type_member = requires { typename T::type; };
+
+} // namespace wheel
+
+#endif // LIBWHEEL_METAPROGRAMMING_HAS_TYPE_MEMBER_HPP

--- a/libwheel/metaprogramming/has_value_member.hpp
+++ b/libwheel/metaprogramming/has_value_member.hpp
@@ -1,0 +1,18 @@
+#ifndef LIBWHEEL_METAPROGRAMMING_HAS_VALUE_MEMBER_HPP
+#define LIBWHEEL_METAPROGRAMMING_HAS_VALUE_MEMBER_HPP
+
+namespace wheel {
+
+/**
+ * @brief Check if specified type has a value member variable
+ *
+ * Concept is satisfied only if specified type has a value member variable.
+ *
+ * @tparam T Type being checked
+ */
+template <typename T>
+concept has_value_member = requires { T::value; };
+
+} // namespace wheel
+
+#endif // LIBWHEEL_METAPROGRAMMING_HAS_VALUE_MEMBER_HPP

--- a/libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp
+++ b/libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp
@@ -1,0 +1,35 @@
+#ifndef LIBWHEEL_METAPROGRAMMING_IS_COMPILE_TIME_INVOCABLE_LAMBDA_HPP
+#define LIBWHEEL_METAPROGRAMMING_IS_COMPILE_TIME_INVOCABLE_LAMBDA_HPP
+
+#include <concepts>
+
+namespace wheel {
+
+/**
+ * @brief Check if a lambda is invocable at compile time
+ *
+ * This overload will be removed from the overload set if the lambda is not compile-time invocable.
+ *
+ * @tparam Lambda Lambda to be evaluated
+ * @param[in] 1 Lambda instance to be evaluated (only used for type deduction)
+ * @return true
+ */
+template <typename Lambda>
+    requires std::default_initializable<Lambda> && std::invocable<Lambda>
+consteval auto is_compile_time_invocable_lambda(Lambda /* lambda */) -> std::enable_if_t<(Lambda{}(), true), bool> {
+    return true;
+}
+
+/**
+ * @brief Check if a lambda is invocable at compile time
+ *
+ * This overload will be used if the templated one is removed from the overload set.
+ *
+ * @param[in] 1 Lambda instance to be evaluated (not used)
+ * @return false
+ */
+consteval auto is_compile_time_invocable_lambda(auto /* lambda */) -> bool { return false; }
+
+} // namespace wheel
+
+#endif // LIBWHEEL_METAPROGRAMMING_IS_COMPILE_TIME_INVOCABLE_LAMBDA_HPP

--- a/libwheel/metaprogramming/type_list.hpp
+++ b/libwheel/metaprogramming/type_list.hpp
@@ -1,0 +1,195 @@
+#ifndef LIBWHEEL_METAPROGRAMMING_TYPE_LIST_HPP
+#define LIBWHEEL_METAPROGRAMMING_TYPE_LIST_HPP
+
+#include <type_traits>
+
+#include "libwheel/metaprogramming/has_type_member.hpp"
+#include "libwheel/metaprogramming/has_value_member.hpp"
+
+namespace wheel {
+
+/**
+ * @brief Struct that contains a compile-time list of types
+ *
+ * @tparam Types Parameter pack containing the TypeList's contained types
+ */
+template <typename... Types>
+struct TypeList {
+    /** @brief Number of elements in the TypeList */
+    static constexpr auto size{std::integral_constant<std::size_t, sizeof...(Types)>::value};
+};
+
+/**
+ * @brief Return the index of a specified type within a TypeList
+ *
+ * This metafunction returns the index of the type to find in a value member variable. If the type to find is not
+ * in the TypeList, the value member variable will not exist.
+ *
+ * This is the primary template.
+ */
+template <typename, typename>
+struct index_of;
+
+/** @brief Return the index of a specified type within a TypeList
+ *
+ * This metafunction returns the index of the type to find in a value member variable. If the type to find is not
+ * in the TypeList, the value member variable will not exist.
+ *
+ * This is the partial template specialization for when the type to find is at the front of the TypeList.
+ *
+ * @tparam FindType Type to search for in the TypeList
+ * @tparam RemainingTypes Parameter pack for the remaining types in the TypeList
+ */
+template <typename FindType, typename... RemainingTypes>
+struct index_of<FindType, TypeList<FindType, RemainingTypes...>> : std::integral_constant<std::size_t, 0U> {};
+
+/**
+ * @brief Return the index of a specified type within a TypeList
+ *
+ * This metafunction returns the index of the type to find in a value member variable. If the type to find is not
+ * in the TypeList, the value member variable will not exist.
+ *
+ * This is the partial template specialization for when the type to find is not at the front of the TypeList.
+ *
+ * @tparam FindType Type to search for in the TypeList
+ * @tparam FrontType Type at the front of the TypeList
+ * @tparam RemainingTypes Parameter pack for the remaining types in the TypeList
+ */
+template <typename FindType, typename FrontType, typename... RemainingTypes>
+    requires has_value_member<index_of<FindType, TypeList<RemainingTypes...>>>
+struct index_of<FindType, TypeList<FrontType, RemainingTypes...>>
+    : std::integral_constant<std::size_t, 1U + index_of<FindType, TypeList<RemainingTypes...>>::value> {};
+
+/**
+ * @brief Helper template to return the index of a specified type within a TypeList
+ *
+ * This is an alias for index_of<FindType, TypeList>::value.
+ *
+ * @tparam FindType Type to search for in the TypeList
+ * @tparam TypeList TypeList being searched through
+ */
+template <typename FindType, typename TypeList>
+    requires has_value_member<index_of<FindType, TypeList>>
+constexpr auto index_of_v = index_of<FindType, TypeList>::value;
+
+/**
+ * @brief Return the type at the beginning of a TypeList
+ *
+ * This metafunction returns the beginning type in a type member alias. If the TypeList is empty, this type member
+ * will not exist.
+ *
+ * This is the primary template.
+ */
+template <typename>
+struct begin_type;
+
+/**
+ * @brief Return the type at the beginning of a TypeList
+ *
+ * This metafunction returns the beginning type in a type member alias. If the TypeList is empty, this type member
+ * will not exist.
+ *
+ * This is the partial template specialization for when the TypeList is nonempty.
+ *
+ * @tparam FrontType Type at the front of the TypeList
+ * @tparam RemainingTypes Paramater pack for the remaining types in the TypeList
+ */
+template <typename FrontType, typename... RemainingTypes>
+struct begin_type<TypeList<FrontType, RemainingTypes...>> : std::type_identity<FrontType> {};
+
+/**
+ * @brief Return the type at the beginning of a TypeList
+ *
+ * This metafunction returns the beginning type in a type member alias. If the TypeList is empty, this type member
+ * will not exist.
+ *
+ * This is the full template specialization for when the TypeList is empty.
+ */
+template <>
+struct begin_type<TypeList<>> {};
+
+/**
+ * @brief Helper template to return the type at the beginning of a TypeList
+ *
+ * This is an alias for begin_type<TypeList>::value.
+ *
+ * @tparam TypeList TypeList to get the beginning type from
+ */
+template <typename TypeList>
+    requires has_type_member<begin_type<TypeList>>
+using begin_type_t = typename begin_type<TypeList>::type;
+
+/**
+ * @brief Return the next type in a TypeList after the specified type
+ *
+ * This metafunction returns the next type in a type member alias. If the TypeList has no next type, this type member
+ * will not exist.
+ *
+ * This is the primary template.
+ */
+template <typename, typename>
+struct next_type;
+
+/**
+ * @brief Return the next type in a TypeList after the specified type
+ *
+ * This metafunction returns the next type in a type member alias. If the TypeList has no next type, this type member
+ * will not exist.
+ *
+ * This is the partial template specialization for when the TypeList is empty.
+ *
+ * @tparam StartType Starting type in the TypeList
+ */
+template <typename StartType>
+struct next_type<StartType, TypeList<>> {};
+
+/**
+ * @brief Return the next type in a TypeList after the specified type
+ *
+ * This metafunction returns the next type in a type member alias. If the TypeList has no next type, this type member
+ * will not exist.
+ *
+ * This is the partial template specialization for when current type is at the beginning of the TypeList.
+ *
+ * @tparam StartType Starting type in the TypeList. Metafunction should return the type after this one
+ * @tparam NextType Type following StartType in the TypeList
+ * @tparam RemainingTypes Parameter pack for the remaining types in the TypeList
+ */
+template <typename StartType, typename NextType, typename... RemainingTypes>
+struct next_type<StartType, TypeList<StartType, NextType, RemainingTypes...>> : std::type_identity<NextType> {};
+
+/**
+ * @brief Return the next type in a TypeList after the specified type
+ *
+ * This metafunction returns the next type in a type member alias. If the TypeList has no next type, this type member
+ * will not exist.
+ *
+ * This is the partial template specialization for when current type is not at the beginning of the TypeList.
+ *
+ * @tparam StartType Starting type in the TypeList. Metafunction should return the type after this one
+ * @tparam FrontType Type at the front of the TypeList
+ * @tparam RemainingTypes Parameter pack for the remaining types in the TypeList
+ */
+template <typename StartType, typename FrontType, typename... RemainingTypes>
+    requires has_type_member<next_type<StartType, TypeList<RemainingTypes...>>>
+struct next_type<StartType, TypeList<FrontType, RemainingTypes...>>
+    : std::type_identity<typename next_type<StartType, TypeList<RemainingTypes...>>::type> {};
+
+/**
+ * @brief Helper template to return the next type in a TypeList after the specified type
+ *
+ * This is an alias for next_type<StartType, TypeList>::value.
+ *
+ * @tparam StartType Current type in the TypeList
+ * @tparam TypeList TypeList to get the next type from
+ */
+template <typename StartType, typename TypeList>
+    requires has_type_member<next_type<StartType, TypeList>>
+using next_type_t = typename next_type<StartType, TypeList>::type;
+
+template <typename StartType, typename TypeList>
+concept has_next_type = has_type_member<next_type<StartType, TypeList>>;
+
+} // namespace wheel
+
+#endif // LIBWHEEL_METAPROGRAMMING_TYPE_LIST_HPP

--- a/test/metaprogramming/CMakeLists.txt
+++ b/test/metaprogramming/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_library(test_metaprogramming
+  test_type_list.cpp
+  test_has_value_member.cpp
+  test_has_type_member.cpp
+  test_is_compile_time_invocable_lambda.cpp
+)
+
+target_link_libraries(test_metaprogramming
+  PRIVATE
+    libwheel::metaprogramming
+)
+
+target_compile_options(test_metaprogramming
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Wpedantic
+    -Wold-style-cast
+    -Wunused
+    -Wconversion
+    -Wsign-conversion
+    -Wcast-align
+    -Woverloaded-virtual
+    -Wdouble-promotion
+    -Wformat=2
+    -Wimplicit-fallthrough
+    -Werror
+)

--- a/test/metaprogramming/test_has_type_member.cpp
+++ b/test/metaprogramming/test_has_type_member.cpp
@@ -1,0 +1,17 @@
+#include <libwheel/metaprogramming/has_type_member.hpp>
+
+/**
+ * @brief Test struct that contains a type member variable
+ */
+struct TypeMember {
+    using type = int;
+};
+
+/**
+ * @brief Test struct that does not contain a type member variable
+ */
+struct NoTypeMember {};
+
+// Compile-time tests
+static_assert(wheel::has_type_member<TypeMember>);
+static_assert(!wheel::has_type_member<NoTypeMember>);

--- a/test/metaprogramming/test_has_value_member.cpp
+++ b/test/metaprogramming/test_has_value_member.cpp
@@ -1,0 +1,17 @@
+#include <libwheel/metaprogramming/has_value_member.hpp>
+
+/**
+ * @brief Test struct that contains a value member variable
+ */
+struct ValueMember {
+    static constexpr auto value{0U};
+};
+
+/**
+ * @brief Test struct that does not contain a value member variable
+ */
+struct NoValueMember {};
+
+// Compile-time tests
+static_assert(wheel::has_value_member<ValueMember>);
+static_assert(!wheel::has_value_member<NoValueMember>);

--- a/test/metaprogramming/test_is_compile_time_invocable_lambda.cpp
+++ b/test/metaprogramming/test_is_compile_time_invocable_lambda.cpp
@@ -1,0 +1,20 @@
+#include <array>
+#include <list>
+#include <vector>
+
+#include <libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp>
+
+// Compile-time test for a lambda that cannot be invoked at compile time
+auto runtime_lambda_static_test() -> void {
+    const int runtime_var{0};
+
+    static_assert(!wheel::is_compile_time_invocable_lambda([&runtime_var] { static_cast<void>(runtime_var); }));
+}
+
+// Compile-time tests
+static_assert(wheel::is_compile_time_invocable_lambda([] {}));
+
+static_assert(wheel::is_compile_time_invocable_lambda([] { static_cast<void>(std::size(std::array<float, 2>{})); }));
+static_assert(std::size(std::array<float, 2>{}) == 2);
+
+static_assert(!wheel::is_compile_time_invocable_lambda([] { static_cast<void>(std::size(std::list<int>{})); }));

--- a/test/metaprogramming/test_type_list.cpp
+++ b/test/metaprogramming/test_type_list.cpp
@@ -1,0 +1,50 @@
+#include <string>
+
+#include <libwheel/metaprogramming/type_list.hpp>
+
+// Compile-time tests for TypeList size
+static_assert(wheel::TypeList<>::size == 0U);
+static_assert(wheel::TypeList<int>::size == 1U);
+static_assert(wheel::TypeList<int, int, int>::size == 3U);
+static_assert(wheel::TypeList<int, std::string, double>::size == 3U);
+
+// Compile-time tests for index of type within a TypeList
+static_assert(wheel::index_of<int, wheel::TypeList<int, char, float>>::value == 0U);
+static_assert(wheel::index_of<char, wheel::TypeList<int, char, float>>::value == 1U);
+static_assert(wheel::index_of<float, wheel::TypeList<int, char, float>>::value == 2U);
+static_assert(wheel::index_of<float, wheel::TypeList<int, float, float>>::value == 1U);
+
+static_assert(!wheel::has_value_member<wheel::index_of<unsigned int, wheel::TypeList<int, char, float>>>);
+
+static_assert(wheel::index_of_v<int, wheel::TypeList<int, char, float>> == 0U);
+static_assert(wheel::index_of_v<char, wheel::TypeList<int, char, float>> == 1U);
+static_assert(wheel::index_of_v<float, wheel::TypeList<int, char, float>> == 2U);
+
+// Compile-time tests for beginning type for a TypeList
+static_assert(std::is_same_v<wheel::begin_type<wheel::TypeList<int>>::type, int>);
+static_assert(std::is_same_v<wheel::begin_type<wheel::TypeList<float, int>>::type, float>);
+static_assert(std::is_same_v<wheel::begin_type<wheel::TypeList<float, float>>::type, float>);
+
+static_assert(!wheel::has_value_member<wheel::begin_type<wheel::TypeList<>>>);
+
+static_assert(std::is_same_v<wheel::begin_type_t<wheel::TypeList<int>>, int>);
+static_assert(std::is_same_v<wheel::begin_type_t<wheel::TypeList<float, int>>, float>);
+static_assert(std::is_same_v<wheel::begin_type_t<wheel::TypeList<float, float>>, float>);
+
+// Compile-time tests for next type in a TypeList
+static_assert(std::is_same_v<wheel::next_type<int, wheel::TypeList<int, float, char>>::type, float>);
+static_assert(std::is_same_v<wheel::next_type<float, wheel::TypeList<int, float, char>>::type, char>);
+static_assert(std::is_same_v<wheel::next_type<float, wheel::TypeList<float, float, char>>::type, float>);
+
+static_assert(!wheel::has_type_member<wheel::next_type<char, wheel::TypeList<int, float, char>>>);
+static_assert(!wheel::has_type_member<wheel::next_type<char, wheel::TypeList<>>>);
+
+static_assert(std::is_same_v<wheel::next_type_t<int, wheel::TypeList<int, float, char>>, float>);
+static_assert(std::is_same_v<wheel::next_type_t<float, wheel::TypeList<int, float, char>>, char>);
+static_assert(std::is_same_v<wheel::next_type_t<float, wheel::TypeList<float, float, char>>, float>);
+
+// Compile-time tests for has next type in a TypeList
+static_assert(wheel::has_next_type<int, wheel::TypeList<int, float, char>>);
+static_assert(wheel::has_next_type<float, wheel::TypeList<int, float, char>>);
+static_assert(!wheel::has_next_type<char, wheel::TypeList<int, float, char>>);
+static_assert(!wheel::has_next_type<char, wheel::TypeList<>>);


### PR DESCRIPTION
This PR migrates the existing code from the `libwheel_metaprogramming` sub-project. There are still some integration cleanup that needs to be done, but that should take place after the other sub-projects get merged.

Closes #6 