### PR TITLE
Migrate the `libwheel_motion_planning` project

### DIFF
--- a/cmake/libwheel_motion_planningConfig.cmake
+++ b/cmake/libwheel_motion_planningConfig.cmake
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Boost COMPONENTS Graph REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/libwheel_motion_planningTargets.cmake)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,4 +1,5 @@
 [requires]
+boost/1.74.0
 gtest/1.13.0
 
 [generators]

--- a/examples/motion_planning/CMakeLists.txt
+++ b/examples/motion_planning/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(${PROJECT_SOURCE_DIR}/cmake/compiler_warnings.cmake)
+
+add_subdirectory(custom_vector_type)
+
+add_executable(rrt rrt.cpp)
+
+target_include_directories(rrt
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_link_libraries(rrt
+  PRIVATE
+    libwheel::motion_planning
+    Eigen3::Eigen
+)
+
+wheel_cmake_target_compiler_warnings(rrt)

--- a/examples/motion_planning/custom_vector_type/CMakeLists.txt
+++ b/examples/motion_planning/custom_vector_type/CMakeLists.txt
@@ -1,0 +1,40 @@
+add_executable(struct_vector struct_vector.cpp)
+
+target_include_directories(struct_vector
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_link_libraries(struct_vector
+  PRIVATE
+    libwheel::motion_planning
+)
+
+wheel_cmake_target_compiler_warnings(struct_vector)
+
+
+add_executable(strongly_typed_vector strongly_typed_vector.cpp)
+
+target_link_libraries(strongly_typed_vector
+  PRIVATE
+    libwheel::motion_planning
+    libwheel::strongly_typed_matrix
+)
+
+wheel_cmake_target_compiler_warnings(strongly_typed_vector)
+
+
+add_executable(eigen_vector eigen_vector.cpp)
+
+target_compile_features(eigen_vector
+  PRIVATE
+    cxx_std_20
+)
+
+target_link_libraries(eigen_vector
+  PRIVATE
+    libwheel::motion_planning
+    Eigen3::Eigen
+)
+
+wheel_cmake_target_compiler_warnings(eigen_vector)

--- a/examples/motion_planning/custom_vector_type/eigen_vector.cpp
+++ b/examples/motion_planning/custom_vector_type/eigen_vector.cpp
@@ -1,0 +1,48 @@
+#include <array>
+#include <iostream>
+
+#include <libwheel/motion_planning/bound_range.hpp>
+#include <libwheel/motion_planning/buffer_type_dispatcher.hpp>
+#include <libwheel/motion_planning/copy_buffer_data_strategy.hpp>
+#include <libwheel/motion_planning/resize_strategy.hpp>
+#include <libwheel/motion_planning/sampler.hpp>
+#include <libwheel/motion_planning/space.hpp>
+
+#include <Eigen/Dense>
+
+using CustomVector = Eigen::Vector3f;
+
+template <typename Derived>
+    requires std::is_base_of_v<Eigen::MatrixBase<Derived>, Derived>
+struct wheel::buffer_type_dispatcher<Derived>
+    : std::type_identity<std::array<typename Derived::Scalar, Derived::RowsAtCompileTime>> {};
+
+template <typename Derived>
+    requires std::is_base_of_v<Eigen::MatrixBase<Derived>, Derived>
+struct wheel::ResizeStrategy<Derived> {
+    static auto resize(Derived &, std::size_t) -> void {}
+};
+
+template <>
+struct wheel::CopyBufferDataStrategy<CustomVector, std::array<float, 3>> {
+    static auto copy(CustomVector &target, const std::array<float, 3> &buffer) -> void {
+        target(0) = std::get<0>(buffer);
+        target(1) = std::get<1>(buffer);
+        target(2) = std::get<2>(buffer);
+    }
+};
+
+int main() {
+    const wheel::Space<CustomVector> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                                           wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
+                                           wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
+
+    wheel::UniformSampler sampler{space};
+
+    for (auto i{0}; i < 20; ++i) {
+        const auto sample{sampler.next_sample()};
+        std::cout << sample.transpose() << '\n';
+    }
+
+    return 0;
+}

--- a/examples/motion_planning/custom_vector_type/strongly_typed_vector.cpp
+++ b/examples/motion_planning/custom_vector_type/strongly_typed_vector.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+
+#include <libwheel/motion_planning/bound_range.hpp>
+#include <libwheel/motion_planning/buffer_type_dispatcher.hpp>
+#include <libwheel/motion_planning/copy_buffer_data_strategy.hpp>
+#include <libwheel/motion_planning/resize_strategy.hpp>
+#include <libwheel/motion_planning/sampler.hpp>
+#include <libwheel/motion_planning/space.hpp>
+
+#include <libwheel/strongly_typed_matrix/strongly_typed_matrix.hpp>
+
+struct IdxX {};
+struct IdxY {};
+
+using RowIdxList = wheel::TypeList<IdxX, IdxY>;
+using CustomVector = wheel::StronglyTypedVector<double, RowIdxList, struct Tag>;
+
+template <>
+struct wheel::buffer_type_dispatcher<CustomVector> : std::type_identity<std::array<double, 2>> {};
+
+template <>
+struct wheel::CopyBufferDataStrategy<CustomVector, std::array<double, 2>> {
+    static auto copy(CustomVector &target, const std::array<double, 2> &buffer) -> void {
+        target.at<IdxX>() = std::get<0>(buffer);
+        target.at<IdxY>() = std::get<1>(buffer);
+    }
+};
+
+auto main() -> int {
+    const wheel::Space<CustomVector> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                                           wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}}};
+
+    wheel::UniformSampler sampler{space};
+
+    for (auto i{0}; i < 20; ++i) {
+        const auto sample{sampler.next_sample()};
+        std::cout << sample.at<IdxX>() << ' ' << sample.at<IdxY>() << '\n';
+    }
+
+    return 0;
+}

--- a/examples/motion_planning/custom_vector_type/struct_vector.cpp
+++ b/examples/motion_planning/custom_vector_type/struct_vector.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+
+#include <libwheel/motion_planning/bound_range.hpp>
+#include <libwheel/motion_planning/buffer_type_dispatcher.hpp>
+#include <libwheel/motion_planning/copy_buffer_data_strategy.hpp>
+#include <libwheel/motion_planning/resize_strategy.hpp>
+#include <libwheel/motion_planning/sampler.hpp>
+#include <libwheel/motion_planning/space.hpp>
+
+struct Point3d {
+    using value_type = float;
+
+    value_type x;
+    value_type y;
+    value_type z;
+};
+
+constexpr auto size(const Point3d &) noexcept -> std::size_t { return 3; }
+
+template <>
+struct wheel::CopyBufferDataStrategy<Point3d, std::array<float, 3>> {
+    static auto copy(Point3d &point, const std::array<float, 3> &buffer) -> void {
+        point.x = std::get<0>(buffer);
+        point.y = std::get<1>(buffer);
+        point.z = std::get<2>(buffer);
+    }
+};
+
+auto print_point(const Point3d &point) { std::cout << point.x << ' ' << point.y << ' ' << point.z << '\n'; }
+
+int main() {
+    const wheel::Space<Point3d> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                                      wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
+                                      wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
+
+    wheel::UniformSampler sampler{space};
+
+    for (auto i{0}; i < 20; ++i) {
+        const auto sample{sampler.next_sample()};
+        print_point(sample);
+    }
+
+    return 0;
+}

--- a/examples/motion_planning/rrt.cpp
+++ b/examples/motion_planning/rrt.cpp
@@ -1,0 +1,65 @@
+#include <fstream>
+#include <iostream>
+
+#include <Eigen/Dense>
+
+#include <libwheel/motion_planning/bound_range.hpp>
+#include <libwheel/motion_planning/rapidly_exploring_random_trees.hpp>
+#include <libwheel/motion_planning/space.hpp>
+
+using R2Vector = Eigen::Vector2f;
+using R2Space = wheel::Space<R2Vector>;
+
+template <>
+struct wheel::CopyBufferDataStrategy<Eigen::Vector2f, std::vector<float>> {
+    static auto copy(Eigen::Vector2f &sample, const std::vector<float> &buffer) {
+        sample[0] = buffer.at(0);
+        sample[1] = buffer.at(1);
+    }
+};
+
+template <>
+struct wheel::ResizeStrategy<Eigen::Vector2f> {
+    static auto resize(Eigen::Vector2f & /* sample */, std::size_t /* new_size */) {}
+};
+
+template <>
+struct wheel::EuclideanDistance<Eigen::Vector2f> {
+    static auto distance(const Eigen::Vector2f &a, const Eigen::Vector2f &b) -> double { return (a - b).norm(); }
+};
+
+template <>
+struct wheel::Interpolator<Eigen::Vector2f> {
+    static auto interpolate(const Eigen::Vector2f &start, const Eigen::Vector2f &stop, std::size_t num_samples)
+        -> std::vector<Eigen::Vector2f> {
+        std::vector<Eigen::Vector2f> samples;
+
+        const auto step_size = (start - stop) / (num_samples - 1U);
+        for (auto i{0U}; i < num_samples; ++i) {
+            samples.emplace_back(start + i * step_size);
+        }
+
+        return samples;
+    }
+};
+
+auto print_path(const std::vector<R2Vector> &path, std::ostream &stream = std::cout) -> void {
+    for (const auto &point : path) {
+        stream << point.transpose().eval() << '\n';
+    }
+}
+
+auto main() -> int {
+    const R2Space space{wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound(5.0)},
+                        wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound(5.0)}};
+
+    const auto path = find_path_rrt(space, R2Vector{2, 3}, R2Vector{1, 1});
+
+    if (path.has_value()) {
+        std::cout << "Path found!\n";
+        std::ofstream filename{"path.txt"};
+        print_path(path.value(), filename);
+    }
+
+    return 0;
+}

--- a/libwheel/motion_planning/CMakeLists.txt
+++ b/libwheel/motion_planning/CMakeLists.txt
@@ -1,0 +1,45 @@
+include(GNUInstallDirs)
+
+add_library(wheel_motion_planningLibrary INTERFACE)
+add_library(libwheel::motion_planning ALIAS wheel_motion_planningLibrary)
+
+target_include_directories(wheel_motion_planningLibrary
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_link_libraries(wheel_motion_planningLibrary
+  INTERFACE
+    Boost::graph
+    libwheel::metaprogramming
+)
+
+target_compile_features(wheel_motion_planningLibrary
+  INTERFACE
+    cxx_std_20
+)
+
+set_target_properties(wheel_motion_planningLibrary PROPERTIES
+  EXPORT_NAME motion_planning
+)
+
+install(TARGETS wheel_motion_planningLibrary
+  EXPORT wheel_motion_planningTargets
+  INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/motion_planning
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/libwheel_motion_planningConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_motion_planning
+)
+
+install(EXPORT wheel_motion_planningTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_motion_planning
+  FILE libwheel_motion_planningTargets.cmake
+  NAMESPACE libwheel::
+)

--- a/libwheel/motion_planning/README.md
+++ b/libwheel/motion_planning/README.md
@@ -1,0 +1,49 @@
+# Wheel Motion Planning Library
+
+This is my motion planning library. More information coming soon!
+
+## Where to go
+
+Want to learn more? Peruse the
+[documentation](adamlm.github.io/libwheel-motion_planning).
+
+Want to contribute? Check out the
+[Wiki](https://github.com/adamlm/libwheel-motion_planning/wiki) tab.
+
+Need some help or want to chat about things? Head to the
+[Discussions](https://github.com/adamlm/libwheel-motion_planning/discussions)
+tab.
+
+## Getting started
+
+### Building from source
+
+1. Install Conan dependencies
+
+   ```shell
+   $ conan install . --output-folder=build --build=missing
+   ```
+
+2. Configure the CMake project
+
+   ```shell
+   $ cmake -B build -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release .
+   ```
+
+3. Build the library
+
+   ```shell
+   $ cmake --build build
+   ```
+
+4. (Optional) Install the library
+
+   ```shell
+   $ sudo cmake --install build  # Install to /usr/local/
+   ```
+
+   or
+
+   ```shell
+   $ cmake --install build --prefix=<install_path>  # Install to custom location
+   ```

--- a/libwheel/motion_planning/bound_range.hpp
+++ b/libwheel/motion_planning/bound_range.hpp
@@ -1,0 +1,43 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_BOUNDS_HPP
+#define LIBWHEEL_MOTION_PLANNING_BOUNDS_HPP
+
+#include <cassert>
+
+#include "libwheel/motion_planning/tagged_value.hpp"
+
+namespace wheel {
+
+/**
+ * @brief Wrapped type representing a BoundRange's lower bound
+ */
+using LowerBound = TaggedValue<double, struct LowerBoundTag>;
+
+/**
+ * @brief Wrapped type representing a BoundRange's upper bound
+ */
+using UpperBound = TaggedValue<double, struct UpperBoundTag>;
+
+/**
+ * @brief One-dimensional bounded range between [lower, upper] (inclusive)
+ *
+ * The lower value must be less than or equal to the upper value
+ */
+struct BoundRange {
+
+    /**
+     * @brief Construct a new BoundRange object
+     *
+     * @param l Lower range value
+     * @param u Upper range value
+     */
+    explicit BoundRange(LowerBound l, UpperBound u) : lower{l}, upper{u} {
+        assert((lower.get() <= upper.get()) && "lower bound must be <= upper bound");
+    }
+
+    LowerBound lower;
+    UpperBound upper;
+};
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_BOUNDS_HPP

--- a/libwheel/motion_planning/buffer_type_dispatcher.hpp
+++ b/libwheel/motion_planning/buffer_type_dispatcher.hpp
@@ -1,0 +1,16 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_BUFFER_TYPE_DISPATCHER_HPP
+#define LIBWHEEL_MOTION_PLANNING_BUFFER_TYPE_DISPATCHER_HPP
+
+#include <libwheel/motion_planning/default_buffer_type.hpp>
+
+namespace wheel {
+
+template <typename VectorType>
+struct buffer_type_dispatcher : default_buffer_type<VectorType> {};
+
+template <typename VectorType>
+using buffer_type_dispatcher_t = typename buffer_type_dispatcher<VectorType>::type;
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_BUFFER_TYPE_DISPATCHER_HPP

--- a/libwheel/motion_planning/copy_buffer_data_strategy.hpp
+++ b/libwheel/motion_planning/copy_buffer_data_strategy.hpp
@@ -1,0 +1,16 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_COPY_BUFFER_DATA_STRATEGY_HPP
+#define LIBWHEEL_MOTION_PLANNING_COPY_BUFFER_DATA_STRATEGY_HPP
+
+namespace wheel {
+
+template <typename VectorType, typename BufferType>
+struct CopyBufferDataStrategy {
+    static auto copy(VectorType &destination, const BufferType &buffer)
+        -> std::enable_if_t<std::same_as<VectorType, BufferType>> {
+        destination = buffer;
+    }
+};
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_COPY_BUFFER_DATA_STRATEGY_HPP

--- a/libwheel/motion_planning/default_buffer_type.hpp
+++ b/libwheel/motion_planning/default_buffer_type.hpp
@@ -1,0 +1,39 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_DEFAULT_BUFFER_TYPE_HPP
+#define LIBWHEEL_MOTION_PLANNING_DEFAULT_BUFFER_TYPE_HPP
+
+#include <array>
+#include <vector>
+
+#include <libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp>
+
+namespace wheel {
+
+template <typename T>
+concept size_defined = [] {
+    using std::size;
+    return requires(T t) { size(t); };
+}();
+
+template <typename T>
+concept compile_time_invocable_size =
+    size_defined<T> && std::default_initializable<T> && is_compile_time_invocable_lambda([] {
+        using std::size;
+        size(T{});
+    });
+
+template <typename VectorType>
+struct default_buffer_type : std::type_identity<std::vector<typename VectorType::value_type>> {};
+
+template <typename VectorType>
+    requires compile_time_invocable_size<VectorType>
+struct default_buffer_type<VectorType> : std::type_identity<std::array<typename VectorType::value_type, [] {
+    using std::size;
+    return size(VectorType{});
+}()>> {};
+
+template <typename VectorType>
+using default_buffer_type_t = typename default_buffer_type<VectorType>::type;
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_DEFAULT_BUFFER_TYPE_HPP

--- a/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -1,0 +1,157 @@
+#ifndef WHEEL_MOTION_RAPIDLY_EXPLORING_RANDOM_TREES_HPP
+#define WHEEL_MOTION_RAPIDLY_EXPLORING_RANDOM_TREES_HPP
+
+#include <algorithm>
+#include <cmath>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+
+#include "libwheel/motion_planning/sampler.hpp"
+
+namespace wheel {
+
+template <typename VectorType>
+struct EuclideanDistance {
+    static auto distance(const VectorType & /* a */, const VectorType & /* b */) -> double;
+};
+
+template <typename VectorType>
+struct Interpolator {
+    static auto interpolate(const VectorType & /* start */, const VectorType & /* stop */, std::size_t /* count */)
+        -> std::vector<VectorType>;
+};
+
+namespace detail {
+
+template <typename GraphType, typename VectorType>
+auto nearest_vertex_to(const GraphType &graph, const VectorType &target) -> typename GraphType::vertex_descriptor {
+    if (boost::num_vertices(graph) == 1) {
+        return *boost::vertices(graph).first;
+    }
+
+    typename GraphType::vertex_descriptor nearest_vertex{0U};
+    auto nearest_distance{std::numeric_limits<double>::max()};
+
+    for (auto [it, end] = boost::vertices(graph); it < end - 1; ++it) {
+        // using wheel::euclidean_distance;
+        const auto distance{EuclideanDistance<VectorType>::distance(graph[*it].config, target)};
+        if (distance < nearest_distance) {
+            nearest_vertex = *it;
+            nearest_distance = distance;
+        }
+    }
+
+    return nearest_vertex;
+}
+
+template <typename TreeType, typename SamplerType>
+auto expand_tree(TreeType &tree, SamplerType &sampler, std::size_t num_samples) -> void {
+    for (auto i{0U}; i < num_samples; ++i) {
+        const auto sampled_config = sampler.next_sample();
+
+        auto nearest_vertex = nearest_vertex_to(tree, sampled_config);
+        // using wheel::interpolate;
+        const auto configs = Interpolator<typename SamplerType::sample_type>::interpolate(tree[nearest_vertex].config,
+                                                                                          sampled_config, 100);
+
+        for (const auto &config : configs) {
+            const auto vertex = boost::add_vertex(typename boost::vertex_bundle_type<TreeType>::type{config}, tree);
+            boost::add_edge(nearest_vertex, vertex, tree);
+
+            // The target vertex from the previous iteration becomes the source for the next one
+            nearest_vertex = vertex;
+        }
+    }
+}
+
+template <typename GraphType, typename VectorType>
+auto path_exists(const GraphType &graph, const VectorType &target) -> bool {
+    double min_dist = std::numeric_limits<double>::max();
+
+    for (auto [vertex, end] = boost::vertices(graph); vertex != end; ++vertex) {
+        using namespace wheel;
+        if (const auto dist = EuclideanDistance<VectorType>::distance(graph[*vertex].config, target); dist < 1.0) {
+            return true;
+        } else {
+            min_dist = std::min(min_dist, dist);
+        }
+    }
+
+    return false;
+}
+
+template <typename GraphType>
+auto find_path_in_graph(const GraphType &graph, const typename GraphType::vertex_descriptor &source,
+                        const typename GraphType::vertex_descriptor &target)
+    -> std::optional<std::vector<typename GraphType::vertex_descriptor>> {
+    std::vector<typename GraphType::vertex_descriptor> predecessors(
+        boost::num_vertices(graph), std::numeric_limits<typename GraphType::vertex_descriptor>::max());
+    predecessors[source] = source;
+
+    auto property_map =
+        boost::make_iterator_property_map(std::begin(predecessors), boost::get(boost::vertex_index, graph));
+    auto visitor = boost::make_bfs_visitor(boost::record_predecessors(property_map, boost::on_tree_edge{}));
+
+    boost::breadth_first_search(graph, boost::vertex(source, graph), boost::visitor(visitor));
+
+    auto predecessor_index = target;
+    std::vector<typename GraphType::vertex_descriptor> path{target};
+
+    while (predecessors[predecessor_index] != predecessor_index) {
+        if (predecessor_index == std::numeric_limits<typename GraphType::vertex_descriptor>::max()) {
+            return std::nullopt;
+        }
+
+        path.push_back(predecessors[predecessor_index]);
+        predecessor_index = predecessors[predecessor_index];
+    }
+
+    std::ranges::reverse(path);
+
+    return path;
+}
+
+} // namespace detail
+
+template <typename SpaceType>
+auto find_path_rrt(const SpaceType &space, const typename SpaceType::vector_type &source,
+                   const typename SpaceType::vector_type &target, std::size_t max_samples = 1000U)
+    -> std::optional<std::vector<typename SpaceType::vector_type>> {
+
+    struct VertexProperties {
+        typename SpaceType::vector_type config;
+    };
+
+    using Tree = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, VertexProperties>;
+
+    Tree tree;
+    const auto source_vertex = boost::add_vertex(VertexProperties{source}, tree);
+
+    UniformSampler sampler{space};
+    for (auto sample_count{0U}; sample_count < max_samples; sample_count += 100U) {
+        detail::expand_tree(tree, sampler, 100U);
+
+        const auto nearest_vertex = detail::nearest_vertex_to(tree, target);
+        const auto target_vertex = boost::add_vertex(VertexProperties{target}, tree);
+
+        boost::add_edge(target_vertex, nearest_vertex, tree);
+        const auto vertex_path = detail::find_path_in_graph(tree, source_vertex, target_vertex);
+
+        if (vertex_path.has_value()) {
+            std::vector<typename SpaceType::vector_type> path;
+            std::ranges::transform(vertex_path.value(), std::back_inserter(path),
+                                   [&tree](const auto &vertex) { return tree[vertex].config; });
+
+            return path;
+        }
+
+        boost::remove_vertex(target_vertex, tree);
+    }
+
+    return std::nullopt;
+}
+
+} // namespace wheel
+
+#endif // WHEEL_MOTION_RAPIDLY_EXPLORING_RANDOM_TREES_HPP

--- a/libwheel/motion_planning/resize_strategy.hpp
+++ b/libwheel/motion_planning/resize_strategy.hpp
@@ -1,0 +1,22 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_RESIZE_STRATEGY_HPP
+#define LIBWHEEL_MOTION_PLANNING_RESIZE_STRATEGY_HPP
+
+#include <cstddef>
+
+namespace wheel {
+
+template <typename T>
+concept resizable = requires(T t, std::size_t s) { t.resize(s); };
+
+template <typename VectorType>
+struct ResizeStrategy {
+    static auto resize(VectorType &vector, std::size_t new_size) -> void {
+        if constexpr (resizable<VectorType>) {
+            vector.resize(new_size);
+        }
+    }
+};
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_RESIZE_STRATEGY_HPP

--- a/libwheel/motion_planning/sampler.hpp
+++ b/libwheel/motion_planning/sampler.hpp
@@ -1,0 +1,56 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_SAMPLER_HPP
+#define LIBWHEEL_MOTION_PLANNING_SAMPLER_HPP
+
+// Standard library headers
+#include <algorithm>
+#include <array>
+#include <random>
+
+#include "libwheel/motion_planning/buffer_type_dispatcher.hpp"
+#include "libwheel/motion_planning/copy_buffer_data_strategy.hpp"
+#include "libwheel/motion_planning/resize_strategy.hpp"
+
+namespace wheel {
+
+template <typename SpaceType, typename DistributionType = std::uniform_real_distribution<>>
+class Sampler {
+  public:
+    using sample_type = typename SpaceType::vector_type;
+    using buffer_type = buffer_type_dispatcher_t<sample_type>;
+
+    explicit Sampler(SpaceType space) : generator_{random_device_()} {
+        static constexpr auto make_distribution = [](const auto &bound_range) {
+            return DistributionType{bound_range.lower.get(), bound_range.upper.get()};
+        };
+
+        std::ranges::transform(std::as_const(space.get_bound_ranges()), std::back_inserter(distributions_),
+                               make_distribution);
+    }
+
+    auto next_sample() -> sample_type {
+        buffer_type buffer{};
+        ResizeStrategy<buffer_type>::resize(buffer, std::size(distributions_));
+
+        std::ranges::transform(distributions_, std::begin(buffer),
+                               [this](auto &distribution) { return distribution(this->generator_); });
+
+        sample_type sample{};
+        ResizeStrategy<sample_type>::resize(sample, std::size(distributions_));
+
+        CopyBufferDataStrategy<sample_type, buffer_type>::copy(sample, buffer);
+
+        return sample;
+    }
+
+  private:
+    std::random_device random_device_{};
+    std::mt19937 generator_;
+    std::vector<DistributionType> distributions_;
+};
+
+template <typename SpaceType>
+using UniformSampler = Sampler<SpaceType, std::uniform_real_distribution<>>;
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_SAMPLER_HPP

--- a/libwheel/motion_planning/space.hpp
+++ b/libwheel/motion_planning/space.hpp
@@ -1,0 +1,46 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_SPACE_HPP
+#define LIBWHEEL_MOTION_PLANNING_SPACE_HPP
+
+#include <array>
+#include <vector>
+
+#include "libwheel/motion_planning/bound_range.hpp"
+
+namespace wheel {
+
+/**
+ * @brief Class representing a mathematical space (set with structure)
+ *
+ * @tparam SpaceVectorType Mathematical vector type associated with space
+ */
+template <typename VectorT>
+class Space {
+  public:
+    using VectorType = VectorT;
+    using vector_type = VectorType;
+    using PathType = std::vector<VectorType>;
+
+    /**
+     * @brief Construct a new Space object
+     *
+     * @tparam BoundRangeType Sequence of BoundedRange types, one for each dimension
+     * @param bound_ranges Bounded range for each space dimension
+     */
+    template <typename... BoundRangeType>
+    explicit Space(BoundRangeType... bound_ranges) : bound_ranges_{bound_ranges...} {}
+
+    /**
+     * @brief Get the Space's bound ranges
+     *
+     * @return const std::array<wheel::BoundRange, kDimensions>& Immutable reference to the space's bound ranges
+     */
+    auto get_bound_ranges() const -> const std::vector<wheel::BoundRange> & { return bound_ranges_; }
+
+
+  private:
+    std::vector<BoundRange> bound_ranges_;
+};
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_SPACE_HPP

--- a/libwheel/motion_planning/tagged_value.hpp
+++ b/libwheel/motion_planning/tagged_value.hpp
@@ -1,0 +1,47 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_TAGGED_VALUE_HPP
+#define LIBWHEEL_MOTION_PLANNING_TAGGED_VALUE_HPP
+
+namespace wheel {
+
+/**
+ * @brief This class wraps a primitive or user-defined type and associates it
+ * with a semantic tag.
+ *
+ * This class structure is based on Jonathan Boccara's blog series on strong
+ * types: https://www.fluentcpp.com/2016/12/05/named-constructors/.
+ *
+ * @tparam StorageType The underlying type being wrapped
+ * @tparam Tag The semantic tag associated with the wrapped type. (This is a
+ * phantom type.)
+ */
+template <typename StorageType, typename Tag>
+class TaggedValue {
+  public:
+    /**
+     * @brief Construct a new TaggedValue object
+     *
+     * @param value Value of the underlying type being wrapped
+     */
+    explicit TaggedValue(StorageType value) : value_{value} {}
+
+    /**
+     * @brief Get a mutable reference to the wrapped type
+     *
+     * @return StorageType& Mutable reference to wrapped type
+     */
+    auto get() noexcept -> StorageType & { return value_; }
+
+    /**
+     * @brief Get an immutable reference to the wrapped type
+     *
+     * @return const StorageType& Immutable reference to wrapped type
+     */
+    auto get() const noexcept -> const StorageType & { return value_; }
+
+  private:
+    StorageType value_;
+};
+
+} // namespace wheel
+
+#endif // LIBWHEEL_MOTION_PLANNING_TAGGED_VALUE_HPP

--- a/test/motion_planning/CMakeLists.txt
+++ b/test/motion_planning/CMakeLists.txt
@@ -1,0 +1,33 @@
+include(GoogleTest)
+
+add_executable(unit_tests
+  test_space.cpp
+)
+
+target_link_libraries(unit_tests
+  PRIVATE
+    libwheel::motion_planning
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_compile_options(unit_tests
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Wpedantic
+    -Wold-style-cast
+    -Wunused
+    -Wconversion
+    -Wsign-conversion
+    -Wcast-align
+    -Woverloaded-virtual
+    -Wdouble-promotion
+    -Wformat=2
+    -Wimplicit-fallthrough
+    -Werror
+)
+
+gtest_discover_tests(unit_tests)

--- a/test/motion_planning/test_space.cpp
+++ b/test/motion_planning/test_space.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <libwheel/motion_planning/space.hpp>
+
+using TestVector = std::vector<float>;
+using TestSpace = wheel::Space<TestVector>;
+
+TEST(SpaceTest, TestGetBoundRanges) {
+    const wheel::BoundRange x_bounds{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}};
+    const wheel::BoundRange y_bounds{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}};
+    const wheel::BoundRange z_bounds{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}};
+
+    TestSpace space{x_bounds, y_bounds, z_bounds};
+
+    const auto bounds{space.get_bound_ranges()};
+
+    EXPECT_DOUBLE_EQ(bounds.at(0).lower.get(), x_bounds.lower.get());
+    EXPECT_DOUBLE_EQ(bounds.at(1).lower.get(), y_bounds.lower.get());
+    EXPECT_DOUBLE_EQ(bounds.at(2).lower.get(), z_bounds.lower.get());
+}


### PR DESCRIPTION
This PR migrates the existing code from the `libwheel_motion_planing` sub-project. There are still some integration cleanup that needs to be done, but that should take place after the other sub-projects get merged.

Closes #4 