### PR TITLE
Fix compile errors for Motion Planning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(libwheel_BUILD_METAPROGRAMMING)
 endif()
 
 if(libwheel_BUILD_MOTION_PLANNING)
-  # add_subdirectory(motion_planning)
+  add_subdirectory(motion_planning)
 endif()
 
 if(libwheel_BUILD_STRONGLY_TYPED_MATRIX)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -1,6 +1,7 @@
 # Install CMake dependency management script
 # The get_cpm.cmake script must be included before CPMAddPackage(...) calls
 set(CPM_DOWNLOAD_VERSION 0.38.2)
+set(CPM_USE_LOCAL_PACKAGES TRUE)
 include(cmake/get_cpm.cmake)
 
 # Packages installed through CPM do not need a find_package(...) call
@@ -27,3 +28,14 @@ CPMAddPackage(NAME range-v3
   OPTIONS
     "RANGES_CXX_STD 20"
 )
+
+CPMAddPackage(NAME Boost
+  GITHUB_REPOSITORY "boostorg/boost"
+  GIT_TAG boost-1.82.0
+  SYSTEM TRUE
+  EXCLUDE_FROM_ALL TRUE
+  OPTIONS
+    "BOOST_INCLUDE_LIBRARIES graph"
+)
+
+find_package(Boost REQUIRED COMPONENTS Graph)

--- a/motion_planning/CMakeLists.txt
+++ b/motion_planning/CMakeLists.txt
@@ -3,3 +3,5 @@ add_subdirectory(libwheel/motion_planning)
 if(wheel_motion_planning_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
   add_subdirectory(test)
 endif()
+
+add_subdirectory(examples)

--- a/motion_planning/examples/CMakeLists.txt
+++ b/motion_planning/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(${PROJECT_SOURCE_DIR}/cmake/compiler_warnings.cmake)
-
 add_subdirectory(custom_vector_type)
 
 add_executable(rrt rrt.cpp)

--- a/motion_planning/examples/custom_vector_type/eigen_vector.cpp
+++ b/motion_planning/examples/custom_vector_type/eigen_vector.cpp
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 
 using CustomVector = Eigen::Vector3f;
+using CustomSpace = wheel::Space<CustomVector>;
 
 template <typename Derived>
     requires std::is_base_of_v<Eigen::MatrixBase<Derived>, Derived>
@@ -33,11 +34,11 @@ struct wheel::CopyBufferDataStrategy<CustomVector, std::array<float, 3>> {
 };
 
 int main() {
-    const wheel::Space<CustomVector> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
-                                           wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
-                                           wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
+    const CustomSpace space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                            wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
+                            wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
 
-    wheel::UniformSampler sampler{space};
+    wheel::UniformSampler<CustomSpace> sampler{space};
 
     for (auto i{0}; i < 20; ++i) {
         const auto sample{sampler.next_sample()};

--- a/motion_planning/examples/custom_vector_type/strongly_typed_vector.cpp
+++ b/motion_planning/examples/custom_vector_type/strongly_typed_vector.cpp
@@ -14,6 +14,7 @@ struct IdxY {};
 
 using RowIdxList = wheel::TypeList<IdxX, IdxY>;
 using CustomVector = wheel::StronglyTypedVector<double, RowIdxList, struct Tag>;
+using CustomSpace = wheel::Space<CustomVector>;
 
 template <>
 struct wheel::buffer_type_dispatcher<CustomVector> : std::type_identity<std::array<double, 2>> {};
@@ -27,10 +28,10 @@ struct wheel::CopyBufferDataStrategy<CustomVector, std::array<double, 2>> {
 };
 
 auto main() -> int {
-    const wheel::Space<CustomVector> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
-                                           wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}}};
+    const CustomSpace space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                            wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}}};
 
-    wheel::UniformSampler sampler{space};
+    wheel::UniformSampler<CustomSpace> sampler{space};
 
     for (auto i{0}; i < 20; ++i) {
         const auto sample{sampler.next_sample()};

--- a/motion_planning/examples/custom_vector_type/struct_vector.cpp
+++ b/motion_planning/examples/custom_vector_type/struct_vector.cpp
@@ -17,6 +17,8 @@ struct Point3d {
 
 constexpr auto size(const Point3d &) noexcept -> std::size_t { return 3; }
 
+using CustomSpace = wheel::Space<Point3d>;
+
 template <>
 struct wheel::CopyBufferDataStrategy<Point3d, std::array<float, 3>> {
     static auto copy(Point3d &point, const std::array<float, 3> &buffer) -> void {
@@ -29,11 +31,11 @@ struct wheel::CopyBufferDataStrategy<Point3d, std::array<float, 3>> {
 auto print_point(const Point3d &point) { std::cout << point.x << ' ' << point.y << ' ' << point.z << '\n'; }
 
 int main() {
-    const wheel::Space<Point3d> space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
-                                      wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
-                                      wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
+    const CustomSpace space{wheel::BoundRange{wheel::LowerBound{-5.0}, wheel::UpperBound{5.0}},
+                            wheel::BoundRange{wheel::LowerBound{0.0}, wheel::UpperBound{1.0}},
+                            wheel::BoundRange{wheel::LowerBound{20.0}, wheel::UpperBound{30.0}}};
 
-    wheel::UniformSampler sampler{space};
+    wheel::UniformSampler<CustomSpace> sampler{space};
 
     for (auto i{0}; i < 20; ++i) {
         const auto sample{sampler.next_sample()};

--- a/motion_planning/examples/rrt.cpp
+++ b/motion_planning/examples/rrt.cpp
@@ -25,7 +25,9 @@ struct wheel::ResizeStrategy<Eigen::Vector2f> {
 
 template <>
 struct wheel::EuclideanDistance<Eigen::Vector2f> {
-    static auto distance(const Eigen::Vector2f &a, const Eigen::Vector2f &b) -> double { return (a - b).norm(); }
+    static auto distance(const Eigen::Vector2f &a, const Eigen::Vector2f &b) -> double {
+        return static_cast<double>((a - b).norm());
+    }
 };
 
 template <>

--- a/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -128,7 +128,7 @@ auto find_path_rrt(const SpaceType &space, const typename SpaceType::vector_type
     Tree tree;
     const auto source_vertex = boost::add_vertex(VertexProperties{source}, tree);
 
-    UniformSampler sampler{space};
+    UniformSampler<SpaceType> sampler{space};
     for (auto sample_count{0U}; sample_count < max_samples; sample_count += 100U) {
         detail::expand_tree(tree, sampler, 100U);
 


### PR DESCRIPTION
The collection compiled fine with GCC but had issues with Clang-14. Clang (all versions) current does not support templated alias type deduction, so the `UniformSampler` space template parameter had to be explicitly specified.

Additionally, Clang-14 had some weird bug when trying to use the size_defined concept. Upgrading to Clang-16 resolved the issue. It's unclear what the problem actually was, but Clang-16 is stable, so it would be better to use the most recent compiler version. Not sure if it was a bug with Clang or a problem with the code itself.

The code now compiles with GCC and Clang (16).

Closes #30