### PR TITLE
Update is_compile_time_invocable_lambda

### DIFF
--- a/metaprogramming/README.md
+++ b/metaprogramming/README.md
@@ -1,5 +1,8 @@
 # The Wheel Metaprogramming Library
 
+This library contains several type traits and metafunctions to supplement the Standard Library's metaprogramming
+features.
+
 ## Using in your project
 
 1. Add Wheel Metaprogramming as a dependency in your project
@@ -16,3 +19,13 @@
        libwheel::metaprogramming
    )
    ```
+
+## Library-specific CMake options
+
+| Option                                    | Default value                | Description                               |
+|-------------------------------------------|------------------------------|-------------------------------------------|
+| `libwheel_metaprogramming_BUILD_LIB`      | `${libwheel_BUILD_LIBS}`     | Build the library                         |
+| `libwheel_metaprogramming_BUILD_TESTS`    | `${libwheel_BUILD_TESTS}`    | Build the library's tests                 |
+| `libwheel_metaprogramming_BUILD_INSTALL`  | `${libwheel_BUILD_INSTALL}`  | Build the library's CMake install targets |
+| `libwheel_metaprogramming_BUILD_DOCS`     | `${libwheel_BUILD_DOCS}`     | Build the library's documentation         |
+| `libwheel_metaprogramming_BUILD_EXAMPLES` | `${libwheel_BUILD_EXAMPLES}` | Build the library's examples              |

--- a/metaprogramming/libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp
+++ b/metaprogramming/libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp
@@ -28,7 +28,12 @@ consteval auto is_compile_time_invocable_lambda(Lambda /* lambda */) -> std::ena
  * @param[in] 1 Lambda instance to be evaluated (not used)
  * @return false
  */
-consteval auto is_compile_time_invocable_lambda(auto /* lambda */) -> bool { return false; }
+consteval auto is_compile_time_invocable_lambda(...) -> bool { // NOLINT(cert-dcl50-cpp)
+    // Linting note: C-style variadic function argument is lowest in overload resolution priority, so this will match
+    // only if the argument cannot be converted to some type of functor. Therefore, we can ignore the linting warning.
+
+    return false;
+}
 
 } // namespace wheel
 

--- a/metaprogramming/test/test_is_compile_time_invocable_lambda.cpp
+++ b/metaprogramming/test/test_is_compile_time_invocable_lambda.cpp
@@ -1,15 +1,21 @@
 #include <array>
 #include <list>
-#include <vector>
 
 #include <libwheel/metaprogramming/is_compile_time_invocable_lambda.hpp>
 
-// Compile-time test for a lambda that cannot be invoked at compile time
+namespace {
+
+// Compile-time test for a lambda that cannot be invoked at compile time.
+[[maybe_unused]]
 auto runtime_lambda_static_test() -> void {
     const int runtime_var{0};
 
+    // Failure case calls function overload with C-style variadic function parameters, so this is expected.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     static_assert(!wheel::is_compile_time_invocable_lambda([&runtime_var] { static_cast<void>(runtime_var); }));
 }
+
+} // namespace
 
 // Compile-time tests
 static_assert(wheel::is_compile_time_invocable_lambda([] {}));
@@ -17,4 +23,6 @@ static_assert(wheel::is_compile_time_invocable_lambda([] {}));
 static_assert(wheel::is_compile_time_invocable_lambda([] { static_cast<void>(std::size(std::array<float, 2>{})); }));
 static_assert(std::size(std::array<float, 2>{}) == 2);
 
+// Failure case calls function overload with C-style variadic function parameters, so this is expected.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
 static_assert(!wheel::is_compile_time_invocable_lambda([] { static_cast<void>(std::size(std::list<int>{})); }));


### PR DESCRIPTION
The false case now uses a C-style variadic parameter so that its the lowest on the overflow matching hierarchy. The unit tests and README.md file for the metaprogramming library have also been updated.

Closes #42 