### PR TITLE
Remove Library suffix from target names

### DIFF
--- a/angle/cmake/libwheel_angleConfig.cmake
+++ b/angle/cmake/libwheel_angleConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/libwheel_angleTargets.cmake)

--- a/angle/libwheel/angle/CMakeLists.txt
+++ b/angle/libwheel/angle/CMakeLists.txt
@@ -1,17 +1,19 @@
-add_library(wheel_angleLibrary INTERFACE)
-add_library(libwheel::angle ALIAS wheel_angleLibrary)
+include(GNUInstallDirs)
 
-target_include_directories(wheel_angleLibrary
+add_library(wheel_angle INTERFACE)
+add_library(libwheel::angle ALIAS wheel_angle)
+
+target_include_directories(wheel_angle
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/angle>
 )
 
-target_compile_features(wheel_angleLibrary
+target_compile_features(wheel_angle
   INTERFACE
     cxx_std_20
 )
 
-target_compile_options(wheel_angleLibrary
+target_compile_options(wheel_angle
   INTERFACE
     -Wall
     -Wextra
@@ -30,11 +32,11 @@ target_compile_options(wheel_angleLibrary
     -Werror
 )
 
-set_target_properties(wheel_angleLibrary PROPERTIES
+set_target_properties(wheel_angle PROPERTIES
   EXPORT_NAME angle
 )
 
-install(TARGETS wheel_angleLibrary
+install(TARGETS wheel_angle
   EXPORT wheel_angleTargets
   INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/geometry/cmake/libwheel_geometryConfig.cmake
+++ b/geometry/cmake/libwheel_geometryConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/libwheel_geometryTargets.cmake)

--- a/geometry/libwheel/geometry/CMakeLists.txt
+++ b/geometry/libwheel/geometry/CMakeLists.txt
@@ -1,29 +1,29 @@
 include(GNUInstallDirs)
 
-add_library(wheel_geometryLibrary INTERFACE)
-add_library(libwheel::geometry ALIAS wheel_geometryLibrary)
+add_library(wheel_geometry INTERFACE)
+add_library(libwheel::geometry ALIAS wheel_geometry)
 
-target_include_directories(wheel_geometryLibrary
+target_include_directories(wheel_geometry
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/geometry>
 )
 
-target_link_libraries(wheel_geometryLibrary
+target_link_libraries(wheel_geometry
   INTERFACE
     Eigen3::Eigen
     range-v3::range-v3
 )
 
-target_compile_features(wheel_geometryLibrary
+target_compile_features(wheel_geometry
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_geometryLibrary PROPERTIES
+set_target_properties(wheel_geometry PROPERTIES
   EXPORT_NAME geometry
 )
 
-install(TARGETS wheel_geometryLibrary
+install(TARGETS wheel_geometry
   EXPORT wheel_geometryTargets
   INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -34,7 +34,7 @@ install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   FILES_MATCHING PATTERN "*.hpp"
 )
 
-install(FILES ${PROJECT_SOURCE_DIR}/cmake/libwheel_geometryConfig.cmake
+install(FILES ${PROJECT_SOURCE_DIR}/geometry/cmake/libwheel_geometryConfig.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_geometry
 )
 

--- a/metaprogramming/libwheel/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/libwheel/metaprogramming/CMakeLists.txt
@@ -1,23 +1,23 @@
 include(GNUInstallDirs)
 
-add_library(wheel_metaprogrammingLibrary INTERFACE)
-add_library(libwheel::metaprogramming ALIAS wheel_metaprogrammingLibrary)
+add_library(wheel_metaprogramming INTERFACE)
+add_library(libwheel::metaprogramming ALIAS wheel_metaprogramming)
 
-target_include_directories(wheel_metaprogrammingLibrary
+target_include_directories(wheel_metaprogramming
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/metaprogramming>
 )
 
-target_compile_features(wheel_metaprogrammingLibrary
+target_compile_features(wheel_metaprogramming
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_metaprogrammingLibrary PROPERTIES
+set_target_properties(wheel_metaprogramming PROPERTIES
   EXPORT_NAME metaprogramming
 )
 
-install(TARGETS wheel_metaprogrammingLibrary
+install(TARGETS wheel_metaprogramming
   EXPORT wheel_metaprogrammingTargets
   INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/motion_planning/libwheel/motion_planning/CMakeLists.txt
+++ b/motion_planning/libwheel/motion_planning/CMakeLists.txt
@@ -1,29 +1,29 @@
 include(GNUInstallDirs)
 
-add_library(wheel_motion_planningLibrary INTERFACE)
-add_library(libwheel::motion_planning ALIAS wheel_motion_planningLibrary)
+add_library(wheel_motion_planning INTERFACE)
+add_library(libwheel::motion_planning ALIAS wheel_motion_planning)
 
-target_include_directories(wheel_motion_planningLibrary
+target_include_directories(wheel_motion_planning
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/motion_planning>
 )
 
-target_link_libraries(wheel_motion_planningLibrary
+target_link_libraries(wheel_motion_planning
   INTERFACE
     Boost::graph
     libwheel::metaprogramming
 )
 
-target_compile_features(wheel_motion_planningLibrary
+target_compile_features(wheel_motion_planning
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_motion_planningLibrary PROPERTIES
+set_target_properties(wheel_motion_planning PROPERTIES
   EXPORT_NAME motion_planning
 )
 
-install(TARGETS wheel_motion_planningLibrary
+install(TARGETS wheel_motion_planning
   EXPORT wheel_motion_planningTargets
   INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -34,7 +34,7 @@ install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   FILES_MATCHING PATTERN "*.hpp"
 )
 
-install(FILES ${PROJECT_SOURCE_DIR}/cmake/libwheel_motion_planningConfig.cmake
+install(FILES ${PROJECT_SOURCE_DIR}/motion_planning/cmake/libwheel_motion_planningConfig.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_motion_planning
 )
 

--- a/strongly_typed_matrix/libwheel/strongly_typed_matrix/CMakeLists.txt
+++ b/strongly_typed_matrix/libwheel/strongly_typed_matrix/CMakeLists.txt
@@ -1,27 +1,27 @@
-add_library(wheel_strongly_typed_matrixLibrary INTERFACE)
-add_library(libwheel::strongly_typed_matrix ALIAS wheel_strongly_typed_matrixLibrary)
+add_library(wheel_strongly_typed_matrix INTERFACE)
+add_library(libwheel::strongly_typed_matrix ALIAS wheel_strongly_typed_matrix)
 
-target_include_directories(wheel_strongly_typed_matrixLibrary
+target_include_directories(wheel_strongly_typed_matrix
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/strongly_typed_matrix>
 )
 
-target_link_libraries(wheel_strongly_typed_matrixLibrary
+target_link_libraries(wheel_strongly_typed_matrix
   INTERFACE
     libwheel::metaprogramming
     Eigen3::Eigen
 )
 
-target_compile_features(wheel_strongly_typed_matrixLibrary
+target_compile_features(wheel_strongly_typed_matrix
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_strongly_typed_matrixLibrary PROPERTIES
+set_target_properties(wheel_strongly_typed_matrix PROPERTIES
   EXPORT_NAME strongly_typed_matrix
 )
 
-install(TARGETS wheel_strongly_typed_matrixLibrary
+install(TARGETS wheel_strongly_typed_matrix
   EXPORT wheel_strongly_typed_matrixTargets
   INCLUDES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
The Library did not provide a whole lot of benefit, and it added extra work to remove the suffix when installing libraries.

Closes #56 