### PR TITLE
Add functions to reduce boilerplate

### DIFF
--- a/angle/libwheel/angle/CMakeLists.txt
+++ b/angle/libwheel/angle/CMakeLists.txt
@@ -1,19 +1,19 @@
-include(GNUInstallDirs)
+include(libwheel_target_set_install_rules)
 
-add_library(wheel_angle INTERFACE)
-add_library(libwheel::angle ALIAS wheel_angle)
+add_library(libwheel_angle INTERFACE)
+add_library(libwheel::angle ALIAS libwheel_angle)
 
-target_include_directories(wheel_angle
+target_include_directories(libwheel_angle
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/angle>
 )
 
-target_compile_features(wheel_angle
+target_compile_features(libwheel_angle
   INTERFACE
     cxx_std_20
 )
 
-target_compile_options(wheel_angle
+target_compile_options(libwheel_angle
   INTERFACE
     -Wall
     -Wextra
@@ -32,23 +32,4 @@ target_compile_options(wheel_angle
     -Werror
 )
 
-set_target_properties(wheel_angle PROPERTIES
-  EXPORT_NAME angle
-)
-
-install(TARGETS wheel_angle
-  EXPORT wheel_angleTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/angle
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-install(EXPORT wheel_angleTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_angle
-  FILE libwheel_angleTargets.cmake
-  NAMESPACE libwheel::
-)
+libwheel_target_set_install_rules(libwheel_angle)

--- a/cmake/libwheel_target_remove_export_name_prefix.cmake
+++ b/cmake/libwheel_target_remove_export_name_prefix.cmake
@@ -1,0 +1,39 @@
+#[=======================================================================[.rst:
+libwheel_target_remove_export_name_prefix
+-----------------------------------------
+
+This module defines a function that removes the ``libwheel_`` prefix from a
+specified Wheel Library target's ``EXPORT_NAME``. By convention, Wheel Library
+names its CMake targets ``libwheel_<library>``, but this naming convention
+makes a user's CMake configuration look like ``libwheel::libwheel_<library>``
+when they want to link against that library.
+
+.. command:: libwheel_target_remove_export_name_prefix
+
+  Remove the ``libwheel_`` prefix from a target's ``EXPORT_NAME``:
+  functions::
+
+    libwheel_target_remove_export_name_prefix(target)
+
+  ``libwheel_target_remove_export_name_prefix()`` removes the ``libwheel_``
+  prefix from a specified target's ``EXPORT_NAME``.
+
+  The options are:
+
+  ``target``
+    Specifies the target that will have its ``EXPORT_NAME`` modified.
+
+#]=======================================================================]
+
+function(libwheel_target_remove_export_name_prefix target prefix)
+
+  if(target MATCHES "${prefix}*")
+    string(REPLACE ${prefix} "" target_no_prefix ${target})
+
+    set_target_properties(${target}
+      PROPERTIES
+        EXPORT_NAME ${target_no_prefix}
+    )
+  endif()
+
+endfunction()

--- a/cmake/libwheel_target_remove_library_prefix.cmake
+++ b/cmake/libwheel_target_remove_library_prefix.cmake
@@ -1,0 +1,32 @@
+#[=======================================================================[.rst:
+libwheel_target_remove_library_prefix
+-------------------------------------
+
+This module defines a function to remove a library's name prefix. Linux- and
+Unix-based systems normally prefix libraries with ``lib``, which can lead to
+clunky names for libraries whose names already start with ``lib``.
+
+.. command:: libwheel_target_remove_library_prefix
+
+  Remove a library's name prefix:
+  functions::
+
+    libwheel_target_remove_library_prefix(target)
+
+  ``libwheel_target_remove_library_prefix()`` removes a library's prefix by
+  setting the ``PREFIX`` property to an empty string.
+
+  The options are:
+
+  ``target``
+    Specifies the target that will have its prefix removed.
+
+#]=======================================================================]
+
+function(libwheel_target_remove_library_prefix target)
+
+  set_target_properties(${target} PROPERTIES
+    PREFIX ""
+  )
+
+endfunction()

--- a/cmake/libwheel_target_set_install_rules.cmake
+++ b/cmake/libwheel_target_set_install_rules.cmake
@@ -1,0 +1,61 @@
+#[=======================================================================[.rst:
+libwheel_target_set_install_rules
+---------------------------------
+
+This module defines a function to set the installation rules for a library. A
+library must have installation rules to be installable after being built, but
+the necessary CMake commands create a lot of duplicate boilerplate code.
+
+.. command:: libwheel_target_set_install_rules
+
+  Set the installation rules for a CMake library and its associated header,
+  package configuration, and imported targets files:
+  functions::
+
+    libwheel_target_set_install_rules(target)
+
+  ``libwheel_target_set_install_rules()`` sets a library's installation rules
+  using the conventional structure for the Wheel Library.
+
+  The options are:
+
+  ``target``
+  Specifies the target that will have installation rules specified for it.
+
+#]=======================================================================]
+
+include(GNUInstallDirs)
+include(libwheel_target_remove_export_name_prefix)
+include(libwheel_target_remove_library_prefix)
+
+function(libwheel_target_set_install_rules target)
+
+  libwheel_target_remove_library_prefix(${target})
+  libwheel_target_remove_export_name_prefix(${target} "wheel_")
+
+  install(TARGETS ${target}
+    EXPORT ${target}Targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+  )
+
+  string(REPLACE "libwheel_" "" target_no_prefix ${target})
+
+  install(FILES ${PROJECT_SOURCE_DIR}/${target_no_prefix}/cmake/${target}Config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${target}
+  )
+
+  install(EXPORT ${target}Targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${target}
+    FILE ${target}Targets.cmake
+    NAMESPACE libwheel::
+  )
+
+endfunction()

--- a/geometry/libwheel/geometry/CMakeLists.txt
+++ b/geometry/libwheel/geometry/CMakeLists.txt
@@ -1,45 +1,22 @@
-include(GNUInstallDirs)
+include(libwheel_target_set_install_rules)
 
-add_library(wheel_geometry INTERFACE)
-add_library(libwheel::geometry ALIAS wheel_geometry)
+add_library(libwheel_geometry INTERFACE)
+add_library(libwheel::geometry ALIAS libwheel_geometry)
 
-target_include_directories(wheel_geometry
+target_include_directories(libwheel_geometry
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/geometry>
 )
 
-target_link_libraries(wheel_geometry
+target_link_libraries(libwheel_geometry
   INTERFACE
     Eigen3::Eigen
     range-v3::range-v3
 )
 
-target_compile_features(wheel_geometry
+target_compile_features(libwheel_geometry
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_geometry PROPERTIES
-  EXPORT_NAME geometry
-)
-
-install(TARGETS wheel_geometry
-  EXPORT wheel_geometryTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/geometry
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-install(FILES ${PROJECT_SOURCE_DIR}/geometry/cmake/libwheel_geometryConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_geometry
-)
-
-install(EXPORT wheel_geometryTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_geometry
-  FILE libwheel_geometryTargets.cmake
-  NAMESPACE libwheel::
-)
+libwheel_target_set_install_rules(libwheel_geometry)

--- a/metaprogramming/libwheel/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/libwheel/metaprogramming/CMakeLists.txt
@@ -1,35 +1,16 @@
-include(GNUInstallDirs)
+include(libwheel_target_set_install_rules)
 
-add_library(wheel_metaprogramming INTERFACE)
-add_library(libwheel::metaprogramming ALIAS wheel_metaprogramming)
+add_library(libwheel_metaprogramming INTERFACE)
+add_library(libwheel::metaprogramming ALIAS libwheel_metaprogramming)
 
-target_include_directories(wheel_metaprogramming
+target_include_directories(libwheel_metaprogramming
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/metaprogramming>
 )
 
-target_compile_features(wheel_metaprogramming
+target_compile_features(libwheel_metaprogramming
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_metaprogramming PROPERTIES
-  EXPORT_NAME metaprogramming
-)
-
-install(TARGETS wheel_metaprogramming
-  EXPORT wheel_metaprogrammingTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/metaprogramming
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-install(EXPORT wheel_metaprogrammingTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_metaprogramming
-  FILE libwheel_metaprogrammingConfig.cmake
-  NAMESPACE libwheel::
-)
+libwheel_target_set_install_rules(libwheel_metaprogramming)

--- a/motion_planning/libwheel/motion_planning/CMakeLists.txt
+++ b/motion_planning/libwheel/motion_planning/CMakeLists.txt
@@ -1,45 +1,22 @@
-include(GNUInstallDirs)
+include(libwheel_target_set_install_rules)
 
-add_library(wheel_motion_planning INTERFACE)
-add_library(libwheel::motion_planning ALIAS wheel_motion_planning)
+add_library(libwheel_motion_planning INTERFACE)
+add_library(libwheel::motion_planning ALIAS libwheel_motion_planning)
 
-target_include_directories(wheel_motion_planning
+target_include_directories(libwheel_motion_planning
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/motion_planning>
 )
 
-target_link_libraries(wheel_motion_planning
+target_link_libraries(libwheel_motion_planning
   INTERFACE
     Boost::graph
     libwheel::metaprogramming
 )
 
-target_compile_features(wheel_motion_planning
+target_compile_features(libwheel_motion_planning
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_motion_planning PROPERTIES
-  EXPORT_NAME motion_planning
-)
-
-install(TARGETS wheel_motion_planning
-  EXPORT wheel_motion_planningTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/motion_planning
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-install(FILES ${PROJECT_SOURCE_DIR}/motion_planning/cmake/libwheel_motion_planningConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_motion_planning
-)
-
-install(EXPORT wheel_motion_planningTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_motion_planning
-  FILE libwheel_motion_planningTargets.cmake
-  NAMESPACE libwheel::
-)
+libwheel_target_set_install_rules(libwheel_motion_planning)

--- a/strongly_typed_matrix/libwheel/strongly_typed_matrix/CMakeLists.txt
+++ b/strongly_typed_matrix/libwheel/strongly_typed_matrix/CMakeLists.txt
@@ -1,39 +1,22 @@
-add_library(wheel_strongly_typed_matrix INTERFACE)
-add_library(libwheel::strongly_typed_matrix ALIAS wheel_strongly_typed_matrix)
+include(libwheel_target_set_install_rules)
 
-target_include_directories(wheel_strongly_typed_matrix
+add_library(libwheel_strongly_typed_matrix INTERFACE)
+add_library(libwheel::strongly_typed_matrix ALIAS libwheel_strongly_typed_matrix)
+
+target_include_directories(libwheel_strongly_typed_matrix
   INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/strongly_typed_matrix>
 )
 
-target_link_libraries(wheel_strongly_typed_matrix
+target_link_libraries(libwheel_strongly_typed_matrix
   INTERFACE
     libwheel::metaprogramming
     Eigen3::Eigen
 )
 
-target_compile_features(wheel_strongly_typed_matrix
+target_compile_features(libwheel_strongly_typed_matrix
   INTERFACE
     cxx_std_20
 )
 
-set_target_properties(wheel_strongly_typed_matrix PROPERTIES
-  EXPORT_NAME strongly_typed_matrix
-)
-
-install(TARGETS wheel_strongly_typed_matrix
-  EXPORT wheel_strongly_typed_matrixTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libwheel/strongly_typed_matrix
-  FILES_MATCHING PATTERN "*.hpp"
-)
-
-install(EXPORT wheel_strongly_typed_matrixTargets
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libwheel_strongly_typed_matrix
-  FILE libwheel_strongly_typed_matrixTargets.cmake
-  NAMESPACE libwheel::
-)
+libwheel_target_set_install_rules(libwheel_strongly_typed_matrix)


### PR DESCRIPTION
These functions call target install commands that are common to all libwheel libraries. There are two helper functions that modify libwheel targets' properties.

Closes #58