### PR TITLE
Add RRT max distance with holes

### DIFF
--- a/motion_planning/examples/CMakeLists.txt
+++ b/motion_planning/examples/CMakeLists.txt
@@ -43,3 +43,26 @@ libwheel_target_set_compiler_warnings(rrt_max_distance
   PRIVATE
   WARNINGS_AS_ERRORS
 )
+
+add_executable(rrt_max_distance_holes rrt_max_distance_holes.cpp)
+
+target_include_directories(rrt_max_distance_holes
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+target_link_libraries(rrt_max_distance_holes
+  PRIVATE
+    libwheel::motion_planning
+    fmt::fmt
+)
+
+target_compile_features(rrt_max_distance_holes
+  PRIVATE
+    cxx_std_20
+)
+
+libwheel_target_set_compiler_warnings(rrt_max_distance_holes
+  PRIVATE
+  WARNINGS_AS_ERRORS
+)

--- a/motion_planning/examples/rrt_max_distance_holes.cpp
+++ b/motion_planning/examples/rrt_max_distance_holes.cpp
@@ -1,0 +1,80 @@
+#include <boost/geometry.hpp>
+#include <boost/geometry/io/io.hpp>
+#include <filesystem>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+#include <fstream>
+#include <iostream>
+#include <libwheel/motion_planning/external/boost_geometry.hpp>
+#include <libwheel/motion_planning/rapidly_exploring_random_trees.hpp>
+#include <string>
+
+using point_t = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
+using polygon_t = boost::geometry::model::polygon<point_t>;
+
+namespace {
+auto make_results_directory(std::filesystem::path const &directory_path) -> void {
+    if (std::error_code ec; !std::filesystem::create_directories(directory_path, ec)) {
+        std::string error_string{"unknown error"};
+        if (ec.value() == 0) {
+            error_string = "file exists";
+        }
+
+        fmt::print(std::cerr, "rrt_max_distance_holes: cannot create directory: {}\n", error_string);
+        std::exit(1U);
+    }
+}
+} // namespace
+
+auto main() -> int {
+    namespace wheel_mp = wheel::motion_planning;
+
+    polygon_t const search_space{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
+                                 {{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0}, {1.0, 2.0}, {1.0, 1.0}}};
+    polygon_t const goal_region{{{4.0, 1.0}, {4.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {4.0, 1.0}}};
+
+    struct RrtRecorderVisitor {
+        using GraphNode = wheel_mp::GraphNode<point_t>;
+
+        auto on_add_node(GraphNode const &node) const noexcept -> void {
+            fmt::print(node_stream.get(), "{};{},{}\n", node.index, node.value.get<0>(), node.value.get<1>());
+        }
+
+        auto on_add_edge(GraphNode const &source, GraphNode const &target) const noexcept -> void {
+            fmt::print(edge_stream.get(), "{};{}\n", source.index, target.index);
+        }
+
+        std::reference_wrapper<std::ofstream> node_stream;
+        std::reference_wrapper<std::ofstream> edge_stream;
+    };
+
+    std::filesystem::path const results_directory{"rrt_max_distance_holes_results"};
+    make_results_directory(results_directory);
+
+    std::ofstream tree_nodes_output{results_directory / "search_tree_nodes.csv"};
+    std::ofstream tree_edges_output{results_directory / "search_tree_edges.csv"};
+    auto const result = wheel_mp::find_path(search_space, point_t(0.1, 0.1), goal_region,
+                                            wheel_mp::MaxDistanceHolesRrt{wheel_mp::MaxExpansions{1000U}, search_space},
+                                            RrtRecorderVisitor{tree_nodes_output, tree_edges_output});
+
+    fmt::print("rrt_max_distance_holes: searching for path\n");
+    if (result) {
+        fmt::print("rrt_max_distance_holes: path found\n");
+
+        std::ofstream path_file{results_directory / "planned_path.csv"};
+        for (auto const &point : result.value()) {
+            fmt::print(path_file, "{},{}\n", point.get<0>(), point.get<1>());
+        }
+
+        std::ofstream search_space_file{results_directory / "search_space.dsv"};
+        fmt::print(search_space_file, "{}", boost::geometry::dsv(search_space, ",", "(", ")", ";", "[", "]", ":"));
+
+        std::ofstream goal_region_file{results_directory / "goal_region.dsv"};
+        fmt::print(goal_region_file, "{}", boost::geometry::dsv(goal_region, ",", "(", ")", ";", "[", "]", ":"));
+
+        return 0;
+    }
+
+    fmt::print("rrt_max_distance_holes: path not found\n");
+    return 1;
+}

--- a/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -219,6 +219,47 @@ class MaxDistanceRrt {
     MaxDistance max_distance_{0.5};
 };
 
+template <typename Space>
+class MaxDistanceHolesRrt {
+  public:
+    template <typename S = Space>
+    using sampler_type = UniformSampler<S>;
+
+    constexpr explicit MaxDistanceHolesRrt(MaxExpansions max_expansions, SearchPeriod search_period,
+                                           MaxDistance max_distance, Space space)
+        : max_expansions_{max_expansions}, search_period_{search_period}, max_distance_{max_distance}, space_{space} {}
+
+    constexpr explicit MaxDistanceHolesRrt(MaxExpansions max_expansions, Space space)
+        : max_expansions_{max_expansions}, space_{space} {}
+
+    constexpr auto get_max_expansions() const noexcept -> MaxExpansions { return max_expansions_; }
+
+    constexpr auto get_search_period() const noexcept -> SearchPeriod { return search_period_; }
+
+    auto do_select_vertex(auto const &sample, auto const &tree) const noexcept {
+        return detail::get_nearest_vertex(sample, tree);
+    }
+
+    template <typename Point>
+    auto do_plan_local_path(Point const &source, Point const &target) const -> std::vector<Point> {
+        auto const is_too_far_from_start = [&source = std::as_const(source), this](auto const &point) {
+            return boost::geometry::distance(source, point) >= this->max_distance_.value ||
+                   !is_within(point, this->space_);
+        };
+
+        auto const stopping_point{detail::find_stopping_point(
+            detail::interpolate_between(source, target, detail::MaxStepSize{0.1}), is_too_far_from_start)};
+
+        return {stopping_point.value()};
+    }
+
+  private:
+    MaxExpansions max_expansions_{0U};
+    SearchPeriod search_period_{1U};
+    MaxDistance max_distance_{0.5};
+    Space space_;
+};
+
 struct incremental_sample_and_search_algorithm_category {};
 
 template <>
@@ -228,6 +269,11 @@ struct customization::search_algorithm_category_impl<SimpleRrt> {
 
 template <>
 struct customization::search_algorithm_category_impl<MaxDistanceRrt> {
+    using type = incremental_sample_and_search_algorithm_category;
+};
+
+template <typename Space>
+struct customization::search_algorithm_category_impl<MaxDistanceHolesRrt<Space>> {
     using type = incremental_sample_and_search_algorithm_category;
 };
 


### PR DESCRIPTION
This implementation builds on the MaxDistanceRrt implementation and additionally avoids holes in the search space (which indicate obstacles).

Closes #76 