### PR TITLE
#78 Update clang-tidy header filter regex

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,6 @@ Checks: >-
     portability-*,
     readability-*
 FormatStyle: 'file'
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'
 ...


### PR DESCRIPTION
This PR updates clang-tidy's header filter regex pattern to look at only project headers (I think---I'm still not entirely sure how the rule gets mapped to clang-tidy's behavior).

Closes #78 