### PR TITLE
Include missing header

### DIFF
--- a/boost_graph_extensions/libwheel/boost_graph_extensions/exceptions.hpp
+++ b/boost_graph_extensions/libwheel/boost_graph_extensions/exceptions.hpp
@@ -4,6 +4,7 @@
 #include <exception>
 
 #include "libwheel/boost_graph_extensions/concepts.hpp"
+#include "libwheel/boost_graph_extensions/type_traits.hpp"
 
 namespace wheel::boost_graph_extensions {
 


### PR DESCRIPTION
This PR includes the missing `type_traits.hpp` header, resolving compiler errors.

Closes #88 