### PR TITLE
Lift local planning functionality out of the RRT strategy classes

### DIFF
--- a/motion_planning/libwheel/motion_planning/detail/find_stopping_point.hpp
+++ b/motion_planning/libwheel/motion_planning/detail/find_stopping_point.hpp
@@ -1,0 +1,25 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_DETAIL_FIND_STOPPING_POINT_HPP
+#define LIBWHEEL_MOTION_PLANNING_DETAIL_FIND_STOPPING_POINT_HPP
+
+#include <optional>
+#include <ranges>
+#include <vector>
+
+#include <boost/geometry.hpp>
+
+namespace wheel::motion_planning::detail {
+
+template <std::ranges::input_range Range, typename UnaryPredicate>
+constexpr auto find_stopping_point(Range &&r, UnaryPredicate should_stop) noexcept
+    -> std::optional<std::ranges::range_value_t<Range>> {
+    if (auto const one_past_stop{std::find_if(std::ranges::begin(r), std::ranges::end(r), should_stop)};
+        one_past_stop != std::cbegin(r)) {
+        return *std::prev(one_past_stop);
+    }
+
+    return std::nullopt;
+}
+
+} // namespace wheel::motion_planning::detail
+
+#endif // LIBWHEEL_MOTION_PLANNING_DETAIL_FIND_STOPPING_POINT_HPP

--- a/motion_planning/libwheel/motion_planning/detail/interpolate_between.hpp
+++ b/motion_planning/libwheel/motion_planning/detail/interpolate_between.hpp
@@ -1,0 +1,38 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_DETAIL_INTERPOLATE_BETWEEN_HPP
+#define LIBWHEEL_MOTION_PLANNING_DETAIL_INTERPOLATE_BETWEEN_HPP
+
+#include <vector>
+
+#include <boost/geometry.hpp>
+
+namespace wheel::motion_planning::detail {
+
+struct MaxStepSize {
+    double value{1.0};
+};
+
+template <typename Point>
+auto interpolate_between(Point const &source, Point const &target, MaxStepSize max_step_size) noexcept
+    -> std::vector<Point> {
+
+    auto const num_steps{std::ceil(boost::geometry::distance(source, target) / max_step_size.value)};
+    auto const normalized_step_size{1.0 / num_steps};
+
+    std::vector<Point> points;
+    for (auto i{0.0}; i < 1.0; i += normalized_step_size) {
+        auto scaled_source{source};
+        boost::geometry::multiply_value(scaled_source, 1 - i);
+
+        auto scaled_target{target};
+        boost::geometry::multiply_value(scaled_target, i);
+
+        boost::geometry::add_point(scaled_source, scaled_target);
+        points.push_back(scaled_source);
+    }
+
+    return points;
+}
+
+} // namespace wheel::motion_planning::detail
+
+#endif // LIBWHEEL_MOTION_PLANNING_DETAIL_INTERPOLATE_BETWEEN_HPP

--- a/motion_planning/libwheel/motion_planning/local_planning.hpp
+++ b/motion_planning/libwheel/motion_planning/local_planning.hpp
@@ -1,0 +1,33 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_LOCAL_PLANNING_HPP
+#define LIBWHEEL_MOTION_PLANNING_LOCAL_PLANNING_HPP
+
+#include <boost/geometry.hpp>
+
+#include "libwheel/motion_planning/detail/find_stopping_point.hpp"
+#include "libwheel/motion_planning/detail/interpolate_between.hpp"
+
+namespace wheel::motion_planning {
+
+namespace detail {
+
+struct straight_line_planner {
+
+    auto operator()(auto const &source, auto const &target) const {
+        auto const exceeds_max_distance = [&source](auto const &point) {
+            return boost::geometry::distance(source, point) >= 1.0;
+        };
+
+        auto const stopping_point{detail::find_stopping_point(
+            detail::interpolate_between(source, target, detail::MaxStepSize{0.1}), exceeds_max_distance)};
+
+        return std::vector{stopping_point.value()};
+    }
+};
+
+} // namespace detail
+
+inline constexpr detail::straight_line_planner straight_line_planner{};
+
+} // namespace wheel::motion_planning
+
+#endif // LIBWHEEL_MOTION_PLANNING_LOCAL_PLANNING_HPP

--- a/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -12,6 +12,7 @@
 #include <libwheel/boost_graph_extensions/type_traits.hpp>
 #include <range/v3/view/iota.hpp>
 
+#include "libwheel/motion_planning/detail/interpolate_between.hpp"
 #include "libwheel/motion_planning/find_path.hpp"
 #include "libwheel/motion_planning/is_within.hpp"
 #include "libwheel/motion_planning/iteration_count.hpp"
@@ -119,43 +120,6 @@ auto search_for_vertex_path(Graph const &graph, wheel::boost_graph_extensions::v
         std::ranges::reverse(path);
 
         return path;
-    }
-
-    return std::nullopt;
-}
-
-struct MaxStepSize {
-    double value{1U};
-};
-
-template <typename Point>
-auto interpolate_between(Point const &source, Point const &target, MaxStepSize max_step_size) noexcept
-    -> std::vector<Point> {
-
-    auto const num_steps{std::ceil(boost::geometry::distance(source, target) / max_step_size.value)};
-    auto const normalized_step_size{1.0 / num_steps};
-
-    std::vector<Point> points;
-    for (auto i{0.0}; i < 1.0; i += normalized_step_size) {
-        auto scaled_source{source};
-        boost::geometry::multiply_value(scaled_source, 1 - i);
-
-        auto scaled_target{target};
-        boost::geometry::multiply_value(scaled_target, i);
-
-        boost::geometry::add_point(scaled_source, scaled_target);
-        points.push_back(scaled_source);
-    }
-
-    return points;
-}
-
-template <std::ranges::input_range Range, typename UnaryPredicate>
-constexpr auto find_stopping_point(Range &&r, UnaryPredicate should_stop) noexcept
-    -> std::optional<std::ranges::range_value_t<Range>> {
-    if (auto const one_past_stop{std::find_if(std::ranges::begin(r), std::ranges::end(r), should_stop)};
-        one_past_stop != std::cbegin(r)) {
-        return *std::prev(one_past_stop);
     }
 
     return std::nullopt;


### PR DESCRIPTION
This PR lifts the local planning functionality from the RRT strategy classes into a `straight_line_planner` class. It currently hard codes the behavior to be similar to the `MaxDistanceRrt` strategy class, but this will be changed in some future work. Some helper functions have been moved from `rapidly_exploring_random_trees.hpp` to their own header files under the `detail/` directory.

Closes #97 