### PR TITLE
Add vertex selection implementation

### DIFF
--- a/motion_planning/libwheel/motion_planning/vertex_selection.hpp
+++ b/motion_planning/libwheel/motion_planning/vertex_selection.hpp
@@ -1,0 +1,25 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_VERTEX_SELECTION_HPP
+#define LIBWHEEL_MOTION_PLANNING_VERTEX_SELECTION_HPP
+
+#include "libwheel/boost_graph_extensions/concepts.hpp"
+
+namespace wheel::motion_planning {
+
+template <typename Metric>
+struct closest_vertex_selector {
+
+    explicit closest_vertex_selector(Metric metric) : metric_{std::move(metric)} {}
+
+    auto operator()(wheel::boost_graph_extensions::boost_graph auto const &graph, auto const &value) const {
+        auto const vertex_range{boost::make_iterator_range(boost::vertices(graph))};
+        return *std::ranges::min_element(vertex_range, std::ranges::less{},
+                                         [this, &graph, &value](auto const &v) { return metric_(graph[v], value); });
+    }
+
+  private:
+    Metric metric_;
+};
+
+} // namespace wheel::motion_planning
+
+#endif // LIBWHEEL_MOTION_PLANNING_VERTEX_SELECTION_HPP


### PR DESCRIPTION
This PR adds the `closest_vertex_selector` that will selected the graph vertex that is closest to a specified value. The callable's constructor requires a metric function to quantify closeness.

Closes #101 