### PR TITLE
Update straight line planner to accept a maximum distance parameter

### DIFF
--- a/motion_planning/libwheel/motion_planning/local_planning.hpp
+++ b/motion_planning/libwheel/motion_planning/local_planning.hpp
@@ -5,16 +5,17 @@
 
 #include "libwheel/motion_planning/detail/find_stopping_point.hpp"
 #include "libwheel/motion_planning/detail/interpolate_between.hpp"
+#include "libwheel/motion_planning/param_types.hpp"
 
 namespace wheel::motion_planning {
 
-namespace detail {
-
-struct straight_line_planner {
+struct StraightLinePlanner {
+  public:
+    explicit StraightLinePlanner(MaxDistance max_distance) : max_distance_{max_distance} {}
 
     auto operator()(auto const &source, auto const &target) const {
-        auto const exceeds_max_distance = [&source](auto const &point) {
-            return boost::geometry::distance(source, point) >= 1.0;
+        auto const exceeds_max_distance = [this, &source](auto const &point) {
+            return boost::geometry::distance(source, point) >= max_distance_.value;
         };
 
         auto const stopping_point{detail::find_stopping_point(
@@ -22,11 +23,10 @@ struct straight_line_planner {
 
         return std::vector{stopping_point.value()};
     }
+
+  private:
+    MaxDistance max_distance_{0.0};
 };
-
-} // namespace detail
-
-inline constexpr detail::straight_line_planner straight_line_planner{};
 
 } // namespace wheel::motion_planning
 

--- a/motion_planning/libwheel/motion_planning/param_types.hpp
+++ b/motion_planning/libwheel/motion_planning/param_types.hpp
@@ -1,0 +1,12 @@
+#ifndef LIBWHEEL_MOTION_PLANNING_PARAM_TYPES_HPP
+#define LIBWHEEL_MOTION_PLANNING_PARAM_TYPES_HPP
+
+namespace wheel::motion_planning {
+
+struct MaxDistance {
+    double value;
+};
+
+} // namespace wheel::motion_planning
+
+#endif // LIBWHEEL_MOTION_PLANNING_PARAM_TYPES_HPP

--- a/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -16,6 +16,7 @@
 #include "libwheel/motion_planning/find_path.hpp"
 #include "libwheel/motion_planning/is_within.hpp"
 #include "libwheel/motion_planning/iteration_count.hpp"
+#include "libwheel/motion_planning/param_types.hpp"
 #include "libwheel/motion_planning/sampling.hpp"
 #include "libwheel/motion_planning/type_traits.hpp"
 
@@ -172,10 +173,6 @@ class SimpleRrt {
   private:
     MaxExpansions max_expansions_{0U};
     SearchPeriod search_period_{1U};
-};
-
-struct MaxDistance {
-    double value;
 };
 
 class MaxDistanceRrt {


### PR DESCRIPTION
This PR changes the `stright_line_planner` to the `StraightLinePlanner`. Beyond the name change, the class now accepts a maximum distance. The value was hard-coded to 1.0 before.

Closes #103 