### PR TITLE
Update `rrt_max_distance_holes` example to use `search_rrt()` function

### DIFF
--- a/motion_planning/examples/rrt_max_distance_holes.cpp
+++ b/motion_planning/examples/rrt_max_distance_holes.cpp
@@ -1,27 +1,25 @@
-#include <boost/geometry.hpp>
-#include <boost/geometry/io/io.hpp>
-#include <filesystem>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
+
+#include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <libwheel/motion_planning/external/boost_geometry.hpp>
-#include <libwheel/motion_planning/rapidly_exploring_random_trees.hpp>
-#include <string>
 
-using point_t = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
-using polygon_t = boost::geometry::model::polygon<point_t>;
+#include <boost/geometry.hpp>
+#include <libwheel/motion_planning/external/boost_geometry.hpp>
+#include <libwheel/motion_planning/local_planning.hpp>
+#include <libwheel/motion_planning/rapidly_exploring_random_trees.hpp>
+#include <libwheel/motion_planning/vertex_selection.hpp>
 
 namespace {
 auto make_results_directory(std::filesystem::path const &directory_path) -> void {
     if (std::error_code ec; !std::filesystem::create_directories(directory_path, ec)) {
-        std::string error_string{"unknown error"};
         if (ec.value() == 0) {
-            error_string = "file exists";
+            // file exists
+            return;
         }
 
-        fmt::print(std::cerr, "rrt_max_distance_holes: cannot create directory: {}\n", error_string);
-        std::exit(1U);
+        fmt::print(std::cerr, "fatal: cannot create directory: unkown error: {}\n", ec.value());
     }
 }
 } // namespace
@@ -29,9 +27,16 @@ auto make_results_directory(std::filesystem::path const &directory_path) -> void
 auto main() -> int {
     namespace wheel_mp = wheel::motion_planning;
 
+    using point_t = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
+    using polygon_t = boost::geometry::model::polygon<point_t>;
+
     polygon_t const search_space{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
                                  {{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0}, {1.0, 2.0}, {1.0, 1.0}}};
     polygon_t const goal_region{{{4.0, 1.0}, {4.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {4.0, 1.0}}};
+
+    static constexpr auto boost_geometry_distance = [](auto const &a, auto const &b) {
+        return boost::geometry::distance(a, b);
+    };
 
     struct RrtRecorderVisitor {
         using GraphNode = wheel_mp::GraphNode<point_t>;
@@ -48,33 +53,37 @@ auto main() -> int {
         std::reference_wrapper<std::ofstream> edge_stream;
     };
 
-    std::filesystem::path const results_directory{"rrt_max_distance_holes_results"};
+    std::filesystem::path const results_directory{"search_results"};
     make_results_directory(results_directory);
 
     std::ofstream tree_nodes_output{results_directory / "search_tree_nodes.csv"};
     std::ofstream tree_edges_output{results_directory / "search_tree_edges.csv"};
-    auto const result = wheel_mp::find_path(search_space, point_t(0.1, 0.1), goal_region,
-                                            wheel_mp::MaxDistanceHolesRrt{wheel_mp::MaxExpansions{1000U}, search_space},
-                                            RrtRecorderVisitor{tree_nodes_output, tree_edges_output});
 
-    fmt::print("rrt_max_distance_holes: searching for path\n");
-    if (result) {
-        fmt::print("rrt_max_distance_holes: path found\n");
+    auto const search_result{wheel_mp::search_rrt(
+        point_t{0.1, 0.1}, goal_region, wheel_mp::UniformSampler{search_space},
+        wheel_mp::closest_vertex_selector{boost_geometry_distance},
+        wheel_mp::StraightLinePlanner{search_space, wheel_mp::MaxDistance{0.5}}, wheel_mp::MaxExpansions{100},
+        wheel_mp::ExpansionsPerSearch{10}, RrtRecorderVisitor{tree_nodes_output, tree_edges_output})};
 
-        std::ofstream path_file{results_directory / "planned_path.csv"};
-        for (auto const &point : result.value()) {
-            fmt::print(path_file, "{},{}\n", point.get<0>(), point.get<1>());
-        }
-
-        std::ofstream search_space_file{results_directory / "search_space.dsv"};
-        fmt::print(search_space_file, "{}", boost::geometry::dsv(search_space, ",", "(", ")", ";", "[", "]", ":"));
-
-        std::ofstream goal_region_file{results_directory / "goal_region.dsv"};
-        fmt::print(goal_region_file, "{}", boost::geometry::dsv(goal_region, ",", "(", ")", ";", "[", "]", ":"));
-
-        return 0;
+    if (!search_result) {
+        std::cout << "path not found\n";
+        return 1;
     }
 
-    fmt::print("rrt_max_distance_holes: path not found\n");
-    return 1;
+    fmt::print("path found\n");
+
+    std::ofstream path_file{results_directory / "planned_path.csv"};
+    for (auto const &point : search_result.value()) {
+        fmt::print(path_file, "{},{}\n", point.get<0>(), point.get<1>());
+    }
+
+    std::ofstream search_space_file{results_directory / "search_space.dsv"};
+    fmt::print(search_space_file, "{}", boost::geometry::dsv(search_space, ",", "(", ")", ";", "[", "]", ":"));
+
+    std::ofstream goal_region_file{results_directory / "goal_region.dsv"};
+    fmt::print(goal_region_file, "{}", boost::geometry::dsv(goal_region, ",", "(", ")", ";", "[", "]", ":"));
+
+    return 0;
+
+    return 0;
 }


### PR DESCRIPTION
This PR updates the `rrt_max_distance_holes` example to use the new `search_rrt()` API instead of the older strategy class version.

Closes #110 