### PR TITLE
Add predicate checker visitor and supporting functions

### DIFF
--- a/boost_graph_extensions/CMakeLists.txt
+++ b/boost_graph_extensions/CMakeLists.txt
@@ -1,3 +1,7 @@
 include(options.cmake)
 
 add_subdirectory(libwheel/boost_graph_extensions)
+
+if(libwheel_boost_graph_extensions_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/boost_graph_extensions/libwheel/boost_graph_extensions/visitors.hpp
+++ b/boost_graph_extensions/libwheel/boost_graph_extensions/visitors.hpp
@@ -1,0 +1,43 @@
+#ifndef LIBWHEEL_BOOST_GRAPH_EXTENSIONS_VISITORS_HPP
+#define LIBWHEEL_BOOST_GRAPH_EXTENSIONS_VISITORS_HPP
+
+#include <boost/graph/visitors.hpp>
+
+#include "libwheel/boost_graph_extensions/concepts.hpp"
+
+namespace wheel::boost_graph_extensions {
+
+template <typename VertexOrEdge>
+struct predicate_satisfied {
+  public:
+    explicit predicate_satisfied(VertexOrEdge vertex_or_edge) : vertex_or_edge_{vertex_or_edge} {}
+
+    auto get_satisfying_descriptor() const noexcept { return vertex_or_edge_; }
+
+  private:
+    VertexOrEdge vertex_or_edge_;
+};
+
+template <typename Predicate, typename EventTag>
+struct predicate_checker : boost::base_visitor<predicate_checker<Predicate, EventTag>> {
+    using event_filter = EventTag;
+
+    explicit predicate_checker(Predicate p) : predicate_{p} {}
+
+    auto operator()(auto vertex_or_edge, boost_graph auto const &graph) const -> void {
+        if (predicate_(vertex_or_edge, graph)) {
+            throw predicate_satisfied{vertex_or_edge};
+        }
+    }
+
+    Predicate predicate_;
+};
+
+template <typename Predicate, typename EventTag>
+auto check_predicate(Predicate p, EventTag /* t */) {
+    return predicate_checker<Predicate, EventTag>{p};
+}
+
+} // namespace wheel::boost_graph_extensions
+
+#endif // LIBWHEEL_BOOST_GRAPH_EXTENSIONS_VISITORS_HPP

--- a/boost_graph_extensions/test/CMakeLists.txt
+++ b/boost_graph_extensions/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(libwheel_boost_graph_extensions_tests
+  test_visitors.cpp
+)
+
+target_link_libraries(libwheel_boost_graph_extensions_tests
+  PRIVATE
+    libwheel::boost_graph_extensions
+    GTest::gtest_main
+)
+
+libwheel_target_set_compiler_warnings(libwheel_boost_graph_extensions_tests
+  PRIVATE
+  COMPILE_WARNING_AS_ERROR TRUE
+)
+
+include(GoogleTest)
+gtest_discover_tests(libwheel_boost_graph_extensions_tests)

--- a/boost_graph_extensions/test/test_visitors.cpp
+++ b/boost_graph_extensions/test/test_visitors.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <libwheel/boost_graph_extensions/type_traits.hpp>
+#include <libwheel/boost_graph_extensions/visitors.hpp>
+
+namespace wheel_bge = wheel::boost_graph_extensions;
+
+TEST(BoostGraphExtensions, PredicateCheckerVertexFound) {
+    boost::adjacency_list graph{};
+    auto const vertex_u{boost::add_vertex(graph)};
+    auto const vertex_v{boost::add_vertex(graph)};
+
+    boost::add_edge(vertex_u, vertex_v, graph);
+
+    auto const visitor{boost::make_bfs_visitor(wheel_bge::check_predicate(
+        [vertex_v](auto vertex, auto const & /* graph */) { return vertex == vertex_v; }, boost::on_examine_vertex{}))};
+
+    EXPECT_THROW(boost::breadth_first_search(graph, vertex_u, boost::visitor(visitor)),
+                 wheel_bge::predicate_satisfied<wheel_bge::vertex_descriptor_t<decltype(graph)>>);
+
+    try {
+        boost::breadth_first_search(graph, vertex_u, boost::visitor(visitor));
+    } catch (wheel_bge::predicate_satisfied<wheel_bge::vertex_descriptor_t<decltype(graph)>> const &result) {
+        EXPECT_EQ(result.get_satisfying_descriptor(), vertex_v);
+    }
+}
+
+TEST(BoostGraphExtensions, PredicateCheckerVertexNotFound) {
+    boost::adjacency_list graph{};
+    auto const vertex_u{boost::add_vertex(graph)};
+    auto const vertex_v{boost::add_vertex(graph)};
+
+    auto const visitor{boost::make_bfs_visitor(wheel_bge::check_predicate(
+        [vertex_v](auto vertex, auto const & /* graph */) { return vertex == vertex_v; }, boost::on_examine_vertex{}))};
+
+    EXPECT_NO_THROW(boost::breadth_first_search(graph, vertex_u, boost::visitor(visitor)));
+}


### PR DESCRIPTION
This PR adds a `predicate_checker` visitor class for use with the Boost Graph Library's graph search functions. This class reduces the amount of boilerplate users need to write for specifying early termination predicates when using the search functions.

This PR also provides a convenience function for creating `predicate_checker` instances. The function uses an interface similar to Boost's built-in visitor factory functions.

Closes #129 