### PR TITLE
Remove `SearchPeriod` class

### DIFF
--- a/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
+++ b/motion_planning/libwheel/motion_planning/rapidly_exploring_random_trees.hpp
@@ -79,10 +79,6 @@ struct null_rrt_visitor {
     auto on_add_edge(auto const & /* source */, auto const & /* target */) const noexcept -> void {}
 };
 
-struct SearchPeriod {
-    std::size_t count;
-};
-
 struct MaxExpansions {
     std::size_t count;
 };


### PR DESCRIPTION
It was unused.

Closes #135 